### PR TITLE
Improve mobile layout for GridFinium web app

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -145,7 +145,7 @@
       <h2>1. Capture</h2>
       <p>Snap or upload a photo of your object on letter or A4 paper. We will calibrate scale locally in your browser.</p>
       <div class="upload-dropzone" id="upload-dropzone">
-        <input type="file" accept="image/*" id="file-input" class="file-input" aria-label="Upload outline photo">
+        <input type="file" accept="image/*" capture="environment" id="file-input" class="file-input" aria-label="Upload outline photo">
         <label for="file-input" class="dropzone-label">
           <strong>Drop image here</strong>
           <span>or click to browse</span>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -22,6 +22,10 @@ body {
   padding: 1.5rem clamp(1.5rem, 4vw, 3rem);
   background: #ffffff;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: flex-start;
 }
 
 .page-header {
@@ -62,6 +66,9 @@ body {
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 1.5rem;
   padding: 2rem clamp(1.5rem, 4vw, 3rem);
+  width: min(100%, 1040px);
+  margin: 0 auto;
+  align-content: start;
 }
 
 .panel {
@@ -229,6 +236,19 @@ button:not(:disabled):hover {
   color: #5b6170;
 }
 
+@media (min-width: 720px) {
+  .page-header,
+  .page-footer {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .actions {
+    justify-content: flex-start;
+  }
+}
+
 @media (max-width: 720px) {
   .page-header,
   .page-footer {
@@ -237,5 +257,82 @@ button:not(:disabled):hover {
 
   .layout {
     padding-inline: 1.25rem;
+  }
+}
+
+@media (max-width: 640px) {
+  body {
+    font-size: 0.95rem;
+  }
+
+  .page-header,
+  .page-footer {
+    gap: 0.75rem;
+  }
+
+  .brand {
+    width: 100%;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .layout {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 1.25rem;
+    padding-block: 1.75rem 2.5rem;
+  }
+
+  .panel {
+    padding: 1.5rem;
+  }
+
+  .upload-dropzone {
+    padding: 2rem 0.75rem;
+  }
+
+  .preview button,
+  .actions button,
+  button.primary {
+    width: 100%;
+  }
+
+  .actions {
+    width: 100%;
+    flex-direction: column;
+  }
+
+  .privacy-note {
+    text-align: left;
+  }
+}
+
+@media (max-width: 480px) {
+  .page-header h1 {
+    font-size: 1.35rem;
+  }
+
+  .tagline {
+    font-size: 0.9rem;
+  }
+
+  .panel {
+    padding: 1.25rem;
+  }
+
+  .upload-dropzone {
+    padding: 1.75rem 0.75rem;
+  }
+
+  .metrics li {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+}
+
+@media (max-width: 360px) {
+  .logo {
+    width: 2.25rem;
+    height: 2.25rem;
   }
 }


### PR DESCRIPTION
## Summary
- expand layout containers to flex configurations that adapt between desktop and handheld breakpoints
- refine typography, spacing, and controls for smaller viewports while keeping desktop presentation intact
- enable direct camera capture on mobile devices for the outline uploader

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ceab55d140833081f30a6ae83a8f6a