### PR TITLE
Allow iOS file picker on dropzone

### DIFF
--- a/frontend/script.js
+++ b/frontend/script.js
@@ -16,6 +16,16 @@
     detectionCanvas.getContext("2d");
   var lastDetectedRegion = null;
 
+  if (fileInput && typeof navigator !== "undefined") {
+    var isIOS = /iP(ad|hone|od)/.test(navigator.platform || "") ||
+      (navigator.userAgent && navigator.userAgent.includes("Mac") &&
+        "ontouchend" in document);
+
+    if (isIOS) {
+      fileInput.removeAttribute("capture");
+    }
+  }
+
   function resetAnalysis() {
     if (!calibrationPreview || !calibrationCanvas || !canvasContext) {
       return;


### PR DESCRIPTION
## Summary
- detect iOS devices on load and remove the `capture` attribute from the upload input
- allow the dropzone button to expose the system photo picker on iPhone while keeping existing behavior elsewhere

## Testing
- No automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68ceb96edb1c8330b9b3bd90d84a77b5