### PR TITLE
Move analyze button into capture panel

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -30,6 +30,9 @@
         <img id="preview-image" alt="Outline preview">
         <button type="button" id="clear-button">Clear</button>
       </div>
+      <div class="capture-actions">
+        <button type="button" class="primary" disabled id="analyze-button">Analyze Outline</button>
+      </div>
     </section>
 
     <section class="panel" id="calibration">
@@ -64,9 +67,6 @@
   </main>
 
   <footer class="page-footer">
-    <div class="actions">
-      <button type="button" class="primary" disabled id="analyze-button">Analyze Outline</button>
-    </div>
     <p class="privacy-note">Your photo stays in the browser. Only derived dimensions will be sent to the backend.</p>
   </footer>
 

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -159,6 +159,12 @@ a:hover {
   justify-self: start;
 }
 
+.capture-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
 .calibration-controls {
   display: flex;
   flex-direction: column;
@@ -350,11 +356,17 @@ button:not(:disabled):hover {
 
   .preview button,
   .actions button,
+  .capture-actions button,
   button.primary {
     width: 100%;
   }
 
   .actions {
+    width: 100%;
+    flex-direction: column;
+  }
+
+  .capture-actions {
     width: 100%;
     flex-direction: column;
   }


### PR DESCRIPTION
## Summary
- relocate the Analyze Outline button into the capture panel so it sits directly beneath the image preview
- add capture-specific layout styles to keep the inline button spacing and responsive behavior consistent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cebc6146688330a5d490ff9f1b390f