### PR TITLE
Adjust capture instructions and headings

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -17,8 +17,15 @@
 
   <main class="layout">
     <section class="panel" id="capture">
-      <h2>1. Capture</h2>
-      <p>Snap or upload a photo of your object on letter or A4 paper. We will calibrate scale locally in your browser.</p>
+      <h2>Capture</h2>
+      <p>Snap or upload a photo of your object on letter or A4 paper.</p>
+      <div class="calibration-controls">
+        <label for="paper-size">Paper size</label>
+        <select id="paper-size" name="paper-size">
+          <option value="letter">US Letter (8.5 x 11 in)</option>
+          <option value="a4">A4 (210 x 297 mm)</option>
+        </select>
+      </div>
       <div class="upload-dropzone" id="upload-dropzone">
         <input type="file" accept="image/*" capture="environment" id="file-input" class="file-input" aria-label="Upload outline photo">
         <label for="file-input" class="dropzone-label">
@@ -36,22 +43,15 @@
     </section>
 
     <section class="panel" id="calibration">
-      <h2>2. Calibrate</h2>
+      <h2>Calibrate</h2>
       <p>Confirm paper size and alignment. We will auto-detect edges; you can tweak corners if needed.</p>
-      <div class="calibration-controls">
-        <label for="paper-size">Paper size</label>
-        <select id="paper-size" name="paper-size">
-          <option value="letter">US Letter (8.5 x 11 in)</option>
-          <option value="a4">A4 (210 x 297 mm)</option>
-        </select>
-      </div>
       <div class="calibration-preview" id="calibration-preview" hidden>
         <canvas id="calibration-canvas"></canvas>
       </div>
     </section>
 
     <section class="panel" id="dimensions">
-      <h2>3. Dimensions</h2>
+      <h2>Dimensions</h2>
       <p>Review the extracted measurements before generating geometry.</p>
       <ul class="metrics">
         <li>


### PR DESCRIPTION
## Summary
- remove numbered prefixes from the capture, calibrate, and dimensions section headers
- update the capture instructions to drop the browser calibration sentence and relocate the paper size selector under the instructions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cee6a28fb88330856112962aa1a4c6