### PR TITLE
Update button label and replace preview after analysis

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -38,7 +38,7 @@
         <button type="button" id="clear-button">Clear</button>
       </div>
       <div class="capture-actions">
-        <button type="button" class="primary" disabled id="analyze-button">Analyze Outline</button>
+        <button type="button" class="primary" disabled id="analyze-button">Gridify</button>
       </div>
     </section>
 

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -480,6 +480,25 @@
 
       window.requestAnimationFrame(function () {
         drawAnalysisOverlay(image, detectedRegion);
+
+        if (calibrationCanvas && preview && previewImage) {
+          var outlinedImageUrl = "";
+
+          try {
+            outlinedImageUrl = calibrationCanvas.toDataURL("image/png");
+          } catch (error) {
+            outlinedImageUrl = "";
+          }
+
+          if (outlinedImageUrl) {
+            previewImage.src = outlinedImageUrl;
+            preview.hidden = false;
+          }
+        }
+
+        if (calibrationPreview) {
+          calibrationPreview.hidden = true;
+        }
       });
     };
     image.src = currentImageDataUrl;


### PR DESCRIPTION
## Summary
- rename the capture action button from "Analyze Outline" to "Gridify"
- replace the preview image with the outlined result after running analysis and hide the calibration preview

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ceead3cdec8330a2b30e15d83c563f