### PR TITLE
Relocate outline metrics beneath Gridify control

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -40,6 +40,16 @@
       <div class="capture-actions">
         <button type="button" class="primary" disabled id="analyze-button">Gridify</button>
       </div>
+      <ul class="metrics capture-metrics">
+        <li>
+          <span class="metric-label">Outline perimeter</span>
+          <span class="metric-value" id="metric-perimeter">--</span>
+        </li>
+        <li>
+          <span class="metric-label">Outline area</span>
+          <span class="metric-value" id="metric-area">--</span>
+        </li>
+      </ul>
     </section>
 
     <section class="panel" id="calibration">
@@ -53,16 +63,6 @@
     <section class="panel" id="dimensions">
       <h2>Dimensions</h2>
       <p>Review the extracted measurements before generating geometry.</p>
-      <ul class="metrics">
-        <li>
-          <span class="metric-label">Outline perimeter</span>
-          <span class="metric-value" id="metric-perimeter">--</span>
-        </li>
-        <li>
-          <span class="metric-label">Outline area</span>
-          <span class="metric-value" id="metric-area">--</span>
-        </li>
-      </ul>
     </section>
   </main>
 

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -231,6 +231,10 @@ a:hover {
   border: 1px solid var(--border);
 }
 
+.capture-metrics {
+  margin-top: 1.5rem;
+}
+
 .metric-label {
   color: #1d1f24;
 }


### PR DESCRIPTION
## Summary
- move the outline perimeter and area metrics from the Dimensions panel to the Capture panel directly under the Gridify button
- adjust styles so the relocated metrics have appropriate spacing in their new placement

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ceee66312c83309d76f86233dd12e5