### PR TITLE
Remove tagline and extra panels from capture page

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,7 +12,6 @@
       <img src="assets/gridfinium-logo.svg" alt="GridFinium" class="logo">
       <h1>GridFinium</h1>
     </div>
-    <p class="tagline">Capture your outline, prep it for the grid.</p>
   </header>
 
   <main class="layout">
@@ -50,19 +49,6 @@
           <span class="metric-value" id="metric-area">--</span>
         </li>
       </ul>
-    </section>
-
-    <section class="panel" id="calibration">
-      <h2>Calibrate</h2>
-      <p>Confirm paper size and alignment. We will auto-detect edges; you can tweak corners if needed.</p>
-      <div class="calibration-preview" id="calibration-preview" hidden>
-        <canvas id="calibration-canvas"></canvas>
-      </div>
-    </section>
-
-    <section class="panel" id="dimensions">
-      <h2>Dimensions</h2>
-      <p>Review the extracted measurements before generating geometry.</p>
     </section>
   </main>
 


### PR DESCRIPTION
## Summary
- remove the header tagline from the capture page
- drop the calibration and dimensions panels so only the capture panel remains

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cef1cdac64833095f2891dab28d2ca