### PR TITLE
Add calibration canvas for outlining

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -32,6 +32,9 @@
           <span>or click to browse</span>
         </label>
       </div>
+      <div class="calibration-preview" id="calibration-preview" hidden>
+        <canvas id="calibration-canvas" aria-hidden="true"></canvas>
+      </div>
       <div class="preview" id="preview" hidden>
         <img id="preview-image" alt="Outline preview">
         <button type="button" id="clear-button">Clear</button>


### PR DESCRIPTION
## Summary
- add a hidden calibration canvas container so the outlining overlay can render when analyzing images

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf034dd274833095ff53cb6f8821e6