### PR TITLE
Use offscreen canvas for analysis preview

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -32,9 +32,6 @@
           <span>or click to browse</span>
         </label>
       </div>
-      <div class="calibration-preview" id="calibration-preview" hidden>
-        <canvas id="calibration-canvas" aria-hidden="true"></canvas>
-      </div>
       <div class="preview" id="preview" hidden>
         <img id="preview-image" alt="Outline preview">
         <button type="button" id="clear-button">Clear</button>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -193,26 +193,6 @@ a:hover {
   outline: none;
 }
 
-.calibration-preview {
-  margin-top: 1.25rem;
-  padding: 1.5rem;
-  background: #fafafa;
-  border: 1px solid var(--border);
-  border-radius: 1rem;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
-.calibration-preview canvas {
-  max-width: 100%;
-  height: auto;
-  display: block;
-  background: #ffffff;
-  border: 1px solid var(--border);
-  border-radius: 0.75rem;
-}
-
 .metrics {
   list-style: none;
   margin: 0;


### PR DESCRIPTION
## Summary
- remove the calibration preview canvas from the upload panel markup and styles
- render the analysis overlay in an offscreen canvas and reuse the existing preview image so only one image is shown
- ensure paper size changes rerender the overlay without exposing the helper canvas

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf04ecb1ac833097299d070158f39e