### PR TITLE
Add client-side paper detection and calibration

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -41,12 +41,12 @@
       </div>
       <ul class="metrics capture-metrics">
         <li>
-          <span class="metric-label">Outline perimeter</span>
-          <span class="metric-value" id="metric-perimeter">--</span>
+          <span class="metric-label">Scale (px per mm)</span>
+          <span class="metric-value" id="metric-scale">--</span>
         </li>
         <li>
-          <span class="metric-label">Outline area</span>
-          <span class="metric-value" id="metric-area">--</span>
+          <span class="metric-label">Paper coverage</span>
+          <span class="metric-value" id="metric-coverage">--</span>
         </li>
       </ul>
     </section>


### PR DESCRIPTION
## Summary
- add browser-side handlers for uploading images, detecting paper bounds, and drawing overlays
- compute paper-based calibration metrics and expose them for downstream steps
- surface scale and coverage feedback in the capture panel UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1ce23a5a8833091a4ac288e5a4cb0