### PR TITLE
Add theme toggle with light and dark modes

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="light">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -11,6 +11,14 @@
     <div class="brand">
       <img src="assets/gridfinium-logo.svg" alt="GridFinium" class="logo">
       <h1>GridFinium</h1>
+    </div>
+    <div class="header-actions">
+      <button type="button" class="theme-toggle" id="theme-toggle" aria-label="Switch to dark mode" aria-pressed="false">
+        <span class="theme-toggle-track" aria-hidden="true">
+          <span class="theme-toggle-thumb"></span>
+        </span>
+        <span class="theme-toggle-text" id="theme-toggle-label">Light mode</span>
+      </button>
     </div>
   </header>
 

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -17,6 +17,92 @@
     detectionCanvas.getContext("2d");
   var lastDetectedRegion = null;
   var calibrationState = null;
+  var themeToggle = document.getElementById("theme-toggle");
+  var themeLabel = document.getElementById("theme-toggle-label");
+  var themeStorageKey = "gridfinium-theme";
+  var themeMediaQuery =
+    typeof window !== "undefined" && window.matchMedia
+      ? window.matchMedia("(prefers-color-scheme: dark)")
+      : null;
+
+  function getStoredTheme() {
+    if (typeof window === "undefined" || !window.localStorage) {
+      return null;
+    }
+    try {
+      var stored = window.localStorage.getItem(themeStorageKey);
+      if (stored === "dark" || stored === "light") {
+        return stored;
+      }
+    } catch (error) {
+      // Local storage might be unavailable (e.g. privacy mode). Ignore errors.
+    }
+    return null;
+  }
+
+  function storeTheme(theme) {
+    if (typeof window === "undefined" || !window.localStorage) {
+      return;
+    }
+    try {
+      window.localStorage.setItem(themeStorageKey, theme);
+    } catch (error) {
+      // Ignore storage errors and keep working with in-memory preference.
+    }
+  }
+
+  function applyTheme(theme) {
+    var nextTheme = theme === "dark" ? "dark" : "light";
+    var root = document.documentElement;
+
+    if (root) {
+      root.setAttribute("data-theme", nextTheme);
+    }
+
+    if (themeToggle) {
+      var isDark = nextTheme === "dark";
+      themeToggle.setAttribute("aria-pressed", isDark ? "true" : "false");
+      themeToggle.setAttribute(
+        "aria-label",
+        isDark ? "Switch to light mode" : "Switch to dark mode"
+      );
+    }
+
+    if (themeLabel) {
+      themeLabel.textContent = nextTheme === "dark" ? "Dark mode" : "Light mode";
+    }
+  }
+
+  var storedThemePreference = getStoredTheme();
+  var prefersDark = themeMediaQuery ? themeMediaQuery.matches : false;
+  applyTheme(storedThemePreference || (prefersDark ? "dark" : "light"));
+
+  if (themeMediaQuery) {
+    var handleThemeChange = function (event) {
+      if (getStoredTheme() !== null) {
+        return;
+      }
+      applyTheme(event.matches ? "dark" : "light");
+    };
+
+    if (typeof themeMediaQuery.addEventListener === "function") {
+      themeMediaQuery.addEventListener("change", handleThemeChange);
+    } else if (typeof themeMediaQuery.addListener === "function") {
+      themeMediaQuery.addListener(handleThemeChange);
+    }
+  }
+
+  if (themeToggle) {
+    themeToggle.addEventListener("click", function () {
+      var currentTheme =
+        document.documentElement.getAttribute("data-theme") === "dark"
+          ? "dark"
+          : "light";
+      var nextTheme = currentTheme === "dark" ? "light" : "dark";
+      applyTheme(nextTheme);
+      storeTheme(nextTheme);
+    });
+  }
 
   if (fileInput && typeof navigator !== "undefined") {
     var isIOS = /iP(ad|hone|od)/.test(navigator.platform || "") ||

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,13 +1,49 @@
 :root {
   color-scheme: light;
   font-family: "Inter", "Segoe UI", sans-serif;
-  background: #f7f7f8;
-  color: #0f0f12;
   line-height: 1.6;
   --accent: #1d4ed8;
   --accent-strong: #1e40af;
   --border: #e6e7eb;
   --muted: #5a5d65;
+  --page-bg: #f7f7f8;
+  --surface: #ffffff;
+  --surface-subtle: #f9f9fb;
+  --text-primary: #0f0f12;
+  --text-secondary: #1b1d21;
+  --metric-value: #0f172a;
+  --button-bg: #f4f4f5;
+  --button-text: #0f0f12;
+  --button-hover-shadow: 0 16px 32px rgba(15, 15, 18, 0.12);
+  --panel-shadow: 0 30px 60px rgba(15, 15, 18, 0.05);
+  --dropzone-active-bg: rgba(29, 78, 216, 0.05);
+  --preview-bg: #ffffff;
+  --button-contrast-bg: #0f0f12;
+  --button-contrast-text: #ffffff;
+  --track-border: rgba(15, 23, 42, 0.08);
+  background-color: var(--page-bg);
+  color: var(--text-primary);
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --border: rgba(148, 163, 184, 0.28);
+  --muted: #94a3b8;
+  --page-bg: #020617;
+  --surface: #0b1628;
+  --surface-subtle: #111f36;
+  --text-primary: #f8fafc;
+  --text-secondary: #e2e8f0;
+  --metric-value: #bfdbfe;
+  --button-bg: #1f2937;
+  --button-text: #f8fafc;
+  --button-hover-shadow: 0 16px 32px rgba(15, 23, 42, 0.45);
+  --panel-shadow: 0 40px 60px rgba(2, 6, 23, 0.55);
+  --dropzone-active-bg: rgba(59, 130, 246, 0.18);
+  --preview-bg: #0f172a;
+  --button-contrast-bg: #e2e8f0;
+  --button-contrast-text: #0f172a;
+  --track-border: rgba(148, 163, 184, 0.35);
 }
 
 * {
@@ -19,8 +55,9 @@ body {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  background: #ffffff;
-  color: inherit;
+  background: var(--page-bg);
+  color: var(--text-primary);
+  transition: background-color 200ms ease, color 200ms ease;
 }
 
 a {
@@ -35,12 +72,13 @@ a:hover {
 .page-header,
 .page-footer {
   padding: 1.75rem clamp(1.5rem, 4vw, 3rem);
-  background: #ffffff;
+  background: var(--surface);
   border: 1px solid var(--border);
   display: flex;
   flex-direction: column;
   gap: 1rem;
   align-items: flex-start;
+  transition: background-color 200ms ease, border-color 200ms ease, color 200ms ease, box-shadow 200ms ease;
 }
 
 .page-header {
@@ -52,6 +90,14 @@ a:hover {
 .brand {
   display: flex;
   align-items: center;
+  gap: 0.75rem;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  width: 100%;
   gap: 0.75rem;
 }
 
@@ -85,14 +131,15 @@ a:hover {
 }
 
 .panel {
-  background: #ffffff;
+  background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 1rem;
   padding: 1.75rem;
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  box-shadow: 0 30px 60px rgba(15, 15, 18, 0.05);
+  box-shadow: var(--panel-shadow);
+  transition: background-color 200ms ease, border-color 200ms ease, color 200ms ease, box-shadow 200ms ease;
 }
 
 .panel h2 {
@@ -105,7 +152,7 @@ a:hover {
 .panel p,
 .panel li,
 .panel label {
-  color: #1b1d21;
+  color: var(--text-secondary);
 }
 
 .upload-dropzone {
@@ -114,13 +161,15 @@ a:hover {
   padding: 2.5rem 1rem;
   text-align: center;
   position: relative;
-  background: #ffffff;
-  transition: border-color 150ms ease, background 150ms ease, color 150ms ease;
+  background: var(--surface);
+  color: var(--text-secondary);
+  transition: border-color 150ms ease, background-color 150ms ease, color 150ms ease;
 }
 
 .upload-dropzone.active {
   border-color: var(--accent);
-  background: rgba(29, 78, 216, 0.05);
+  background: var(--dropzone-active-bg);
+  color: var(--text-primary);
 }
 
 .file-input {
@@ -134,12 +183,12 @@ a:hover {
   display: grid;
   gap: 0.5rem;
   font-size: 0.95rem;
-  color: #2c2d32;
+  color: var(--text-secondary);
 }
 
 .dropzone-label strong {
   font-size: 1rem;
-  color: #0f0f12;
+  color: var(--text-primary);
 }
 
 .preview {
@@ -152,7 +201,8 @@ a:hover {
   border-radius: 0.75rem;
   border: 1px solid var(--border);
   object-fit: contain;
-  background: #ffffff;
+  background: var(--preview-bg);
+  transition: background-color 200ms ease, border-color 200ms ease;
 }
 
 .preview button {
@@ -174,7 +224,7 @@ a:hover {
 
 .calibration-controls label {
   font-weight: 600;
-  color: #131318;
+  color: var(--text-primary);
 }
 
 .calibration-controls select {
@@ -182,7 +232,7 @@ a:hover {
   border-radius: 0.5rem;
   border: 1px solid var(--border);
   font-size: 0.95rem;
-  background: #ffffff;
+  background: var(--surface);
   color: inherit;
   transition: border-color 150ms ease, box-shadow 150ms ease;
 }
@@ -207,8 +257,9 @@ a:hover {
   justify-content: space-between;
   padding: 0.75rem 1rem;
   border-radius: 0.75rem;
-  background: #f9f9fb;
+  background: var(--surface-subtle);
   border: 1px solid var(--border);
+  transition: background-color 200ms ease, border-color 200ms ease, color 200ms ease;
 }
 
 .capture-metrics {
@@ -216,13 +267,13 @@ a:hover {
 }
 
 .metric-label {
-  color: #1d1f24;
+  color: var(--text-secondary);
 }
 
 .metric-value {
   font-family: "Source Code Pro", "Consolas", monospace;
   font-size: 0.95rem;
-  color: #0f172a;
+  color: var(--metric-value);
 }
 
 .page-footer {
@@ -246,9 +297,9 @@ button {
   font-size: 1rem;
   font-weight: 600;
   cursor: pointer;
-  transition: transform 120ms ease, box-shadow 120ms ease, border-color 120ms ease;
-  background: #f4f4f5;
-  color: #0f0f12;
+  transition: transform 120ms ease, box-shadow 120ms ease, border-color 120ms ease, background-color 120ms ease, color 120ms ease;
+  background: var(--button-bg);
+  color: var(--button-text);
 }
 
 button:disabled {
@@ -270,13 +321,13 @@ button.primary:disabled {
 }
 
 button.secondary {
-  background: #0f0f12;
-  color: #ffffff;
+  background: var(--button-contrast-bg);
+  color: var(--button-contrast-text);
 }
 
 button:not(:disabled):hover {
   transform: translateY(-1px);
-  box-shadow: 0 16px 32px rgba(15, 15, 18, 0.12);
+  box-shadow: var(--button-hover-shadow);
   border-color: var(--accent-strong);
 }
 
@@ -286,12 +337,92 @@ button:not(:disabled):hover {
   color: var(--muted);
 }
 
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.35rem 0.6rem;
+  border-radius: 999px;
+  background: var(--surface-subtle);
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  font-weight: 600;
+  line-height: 1;
+  box-shadow: 0 12px 24px rgba(15, 15, 18, 0.08);
+  transition: background-color 180ms ease, border-color 180ms ease, color 180ms ease, box-shadow 180ms ease;
+}
+
+.theme-toggle:hover {
+  border-color: var(--accent);
+  box-shadow: 0 18px 32px rgba(15, 15, 18, 0.12);
+}
+
+.theme-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.theme-toggle-track {
+  width: 2.75rem;
+  height: 1.35rem;
+  border-radius: 999px;
+  background: var(--surface);
+  position: relative;
+  box-shadow: inset 0 0 0 1px var(--track-border);
+  transition: background-color 200ms ease, box-shadow 200ms ease;
+}
+
+.theme-toggle-thumb {
+  position: absolute;
+  top: 50%;
+  left: 0.2rem;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 999px;
+  background: var(--accent);
+  transform: translate(0, -50%);
+  transition: transform 220ms ease, background-color 220ms ease, box-shadow 220ms ease;
+  box-shadow: 0 4px 12px rgba(29, 78, 216, 0.35);
+}
+
+.theme-toggle-text {
+  white-space: nowrap;
+}
+
+:root[data-theme="dark"] .theme-toggle {
+  background: rgba(148, 163, 184, 0.08);
+  border-color: rgba(148, 163, 184, 0.25);
+  color: var(--text-primary);
+  box-shadow: 0 24px 40px rgba(2, 6, 23, 0.45);
+}
+
+:root[data-theme="dark"] .theme-toggle:hover {
+  box-shadow: 0 28px 48px rgba(2, 6, 23, 0.55);
+}
+
+:root[data-theme="dark"] .theme-toggle-track {
+  background: rgba(15, 23, 42, 0.9);
+  box-shadow: inset 0 0 0 1px var(--track-border);
+}
+
+:root[data-theme="dark"] .theme-toggle-thumb {
+  background: #facc15;
+  transform: translate(1.35rem, -50%);
+  box-shadow: 0 4px 12px rgba(250, 204, 21, 0.4);
+}
+
 @media (min-width: 720px) {
   .page-header,
   .page-footer {
     flex-direction: row;
     align-items: center;
     justify-content: space-between;
+  }
+
+  .header-actions {
+    width: auto;
+    margin-left: auto;
   }
 
   .actions {
@@ -316,6 +447,10 @@ button:not(:disabled):hover {
     border-radius: 0;
     border-left: none;
     border-right: none;
+  }
+
+  .header-actions {
+    width: 100%;
   }
 
   .brand {


### PR DESCRIPTION
## Summary
- add a header toggle for switching between light and dark themes
- introduce theme-aware design tokens and component styles for consistent appearance
- persist theme selection and honor system preference with graceful fallbacks

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d1f318b0d08330881140e623af0ca7