### PR TITLE
Update branding logo and add favicon

### DIFF
--- a/frontend/assets/gridfinium-logo.svg
+++ b/frontend/assets/gridfinium-logo.svg
@@ -1,16 +1,13 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 200">
-  <title>GridFinium logo</title>
-  <path fill="#000" d="M40 12h80c11.05 0 20 8.95 20 20v58c0 11.05-8.95 20-20 20H94v-18h26c3.31 0 6-2.69 6-6V38c0-3.31-2.69-6-6-6H46c-3.31 0-6 2.69-6 6v124c0 3.31 2.69 6 6 6h34v18H50c-16.57 0-30-13.43-30-30V32c0-11.05 8.95-20 20-20Z"/>
-  <path fill="#000" d="M112 46H48l-10-20h84l-10 20Zm-14 12H62l10 20h26l10-20Zm-18 28-10 18h36l-10-18Z"/>
-  <g fill="#000">
-    <rect x="48" y="126" width="18" height="18" rx="2"/>
-    <rect x="70" y="126" width="18" height="18" rx="2"/>
-    <rect x="92" y="126" width="18" height="18" rx="2"/>
-    <rect x="48" y="148" width="18" height="18" rx="2"/>
-    <rect x="70" y="148" width="18" height="18" rx="2"/>
-    <rect x="92" y="148" width="18" height="18" rx="2"/>
-    <rect x="48" y="170" width="18" height="18" rx="2"/>
-    <rect x="70" y="170" width="18" height="18" rx="2"/>
-    <rect x="92" y="170" width="18" height="18" rx="2"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="logoTitle logoDesc">
+  <title id="logoTitle">GridFinium logo</title>
+  <desc id="logoDesc">Stylized 3D printer outline with a grid build plate</desc>
+  <g fill="none" stroke="#0B0B0B" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="12" y="16" width="104" height="100" rx="10"/>
+    <path d="M28 96h72v16H28z"/>
+    <path d="M28 40h28l8-12h32"/>
+    <path d="M64 28v32"/>
+    <rect x="52" y="60" width="24" height="14" rx="4"/>
+    <rect x="36" y="80" width="56" height="28" rx="4"/>
+    <path d="M36 91.33h56M36 102.67h56M54.67 80v28M73.33 80v28"/>
   </g>
 </svg>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>GridFinium Browser Flow</title>
+  <link rel="icon" type="image/svg+xml" href="assets/gridfinium-logo.svg">
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- refresh the GridFinium logo with a new 3D printer line-art design that matches the provided branding
- reuse the updated SVG as the site favicon so browser tabs display the custom logo

## Testing
- not run (static asset update)

------
https://chatgpt.com/codex/tasks/task_e_68d208695ae48330971f9eabe7259238