### PR TITLE
Remove paper coverage metric box

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -56,10 +56,6 @@
           <span class="metric-label">Scale (px per mm)</span>
           <span class="metric-value" id="metric-scale">--</span>
         </li>
-        <li>
-          <span class="metric-label">Paper coverage</span>
-          <span class="metric-value" id="metric-coverage">--</span>
-        </li>
       </ul>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- remove the paper coverage metric from the capture panel so only scale is shown

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d21427899c8330bbeb4cdb7015b1f4