### PR TITLE
Fix corner handles appearance on mobile

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -226,7 +226,7 @@ a:hover {
   position: absolute;
   width: 24px;
   height: 24px;
-  border-radius: 999px;
+  border-radius: 50%;
   border: 2px solid var(--surface);
   background: rgba(59, 130, 246, 0.9);
   box-shadow: 0 4px 12px rgba(15, 23, 42, 0.2);
@@ -236,10 +236,17 @@ a:hover {
   z-index: 5;
   touch-action: none;
   display: none;
+  -webkit-appearance: none;
+  appearance: none;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  min-height: 0;
+  aspect-ratio: 1 / 1;
 }
 
 .quad-handle.quad-handle--active {
-  display: block;
+  display: inline-flex;
 }
 
 .quad-handle:active {


### PR DESCRIPTION
## Summary
- adjust the quad handle styling so the draggable controls render as circular elements on mobile browsers
- ensure active handles use inline-flex layout to keep the circles from stretching when shown

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d21650963883309fabb7407cb9edc1