### PR TITLE
Limit calibration corner markers to edge lengths

### DIFF
--- a/frontend/script.js
+++ b/frontend/script.js
@@ -664,7 +664,7 @@
       ? Math.max(overlayBounds.width, overlayBounds.height)
       : Math.max(canvasWidth, canvasHeight);
     var lineWidth = Math.max(3, Math.round(diagLength * 0.008));
-    var cornerLength = Math.max(18, Math.round(diagLength * 0.12));
+    var baseCornerLength = Math.max(18, Math.round(diagLength * 0.12));
 
     canvasContext.strokeStyle = "#2fff7f";
     canvasContext.lineWidth = lineWidth;
@@ -700,16 +700,19 @@
       dxPrev /= lenPrev;
       dyPrev /= lenPrev;
 
+      var nextCornerLength = Math.min(baseCornerLength, lenNext * 0.35);
+      var prevCornerLength = Math.min(baseCornerLength, lenPrev * 0.35);
+
       canvasContext.moveTo(current.x, current.y);
       canvasContext.lineTo(
-        current.x + dxPrev * cornerLength,
-        current.y + dyPrev * cornerLength
+        current.x + dxPrev * prevCornerLength,
+        current.y + dyPrev * prevCornerLength
       );
 
       canvasContext.moveTo(current.x, current.y);
       canvasContext.lineTo(
-        current.x + dxNext * cornerLength,
-        current.y + dyNext * cornerLength
+        current.x + dxNext * nextCornerLength,
+        current.y + dyNext * nextCornerLength
       );
     }
 


### PR DESCRIPTION
## Summary
- cap the overlay corner marker segments so they never extend beyond 35% of the adjacent edge length
- use the clamped lengths when rendering the calibration overlay to prevent the stretched endpoints seen in the preview

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d219268f988330bb057d7aec9c8026