### PR TITLE
Fix mobile preview buttons from stretching handles

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -573,7 +573,7 @@ button:not(:disabled):hover {
     padding: 2rem 0.75rem;
   }
 
-  .preview button,
+  .preview button:not(.quad-handle),
   .actions button,
   .capture-actions button,
   button.primary {


### PR DESCRIPTION
## Summary
- prevent the mobile button width rule from targeting draggable quad handles so they keep their fixed size

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d27f634a60833088bb3ac2232f6a5d