### PR TITLE
Add homography warp preview

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -70,6 +70,12 @@
           </div>
         </li>
       </ul>
+      <section class="warp-preview" id="warp-preview" hidden>
+        <h3>Perspective-corrected (top-down) view</h3>
+        <canvas id="warped-canvas" width="0" height="0" aria-label="Perspective-corrected paper"></canvas>
+        <p class="warp-diagnostic" id="warp-reprojection" aria-live="polite"></p>
+        <p class="warp-error" id="warp-error" role="status" hidden></p>
+      </section>
     </section>
   </main>
 
@@ -77,7 +83,8 @@
     <p class="privacy-note">Your photo stays in the browser</p>
   </footer>
 
-  <script src="script.js"></script>
+  <script defer src="https://docs.opencv.org/4.x/opencv.js"></script>
+  <script defer src="script.js"></script>
 </body>
 </html>
 

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -366,6 +366,61 @@ a:hover {
   margin-top: 1.5rem;
 }
 
+.warp-preview {
+  margin-top: 1.5rem;
+  padding: 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--border);
+  background: var(--surface-subtle);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.warp-preview[hidden] {
+  display: none !important;
+}
+
+.warp-preview[data-status="warning"],
+.warp-preview[data-status="error"] {
+  border-color: #b91c1c;
+}
+
+.warp-preview h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.warp-preview canvas {
+  width: 100%;
+  height: auto;
+  border-radius: 0.5rem;
+  border: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.warp-diagnostic {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.warp-diagnostic[data-status="warning"] {
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+.warp-error {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #b91c1c;
+}
+
+.warp-error[hidden] {
+  display: none !important;
+}
+
 .metric-label {
   color: var(--text-secondary);
 }


### PR DESCRIPTION
## Summary
- add an OpenCV.js-powered homography workflow that validates corners, warps the image, and stores transform helpers
- render a perspective-corrected preview canvas with diagnostics and error handling beneath the calibration metrics
- extend styling and script bootstrapping to support the new warp section and OpenCV runtime readiness

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d296acb6b08330b0e9e2cab86149a7