### PR TITLE
Configure OpenCV locateFile for CDN wasm

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -83,6 +83,22 @@
     <p class="privacy-note">Your photo stays in the browser</p>
   </footer>
 
+  <script>
+    window.Module = window.Module || {};
+    window.Module.locateFile = function (path) {
+      if (typeof path !== "string") {
+        return path;
+      }
+      if (
+        path.endsWith(".wasm") ||
+        path.endsWith(".data") ||
+        path.endsWith(".mem")
+      ) {
+        return "https://docs.opencv.org/4.x/" + path;
+      }
+      return path;
+    };
+  </script>
   <script defer src="https://docs.opencv.org/4.x/opencv.js"></script>
   <script defer src="script.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- define a `locateFile` implementation before loading OpenCV.js so the runtime fetches WASM assets from the CDN

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d309fe8c188330906daaa8709d2ce6