### PR TITLE
Limit contour rendering to top three shapes

### DIFF
--- a/frontend/scripts.js
+++ b/frontend/scripts.js
@@ -5,6 +5,8 @@ const DOM_IDS = {
 };
 
 const POLL_INTERVAL_MS = 50;
+// Only keep the top three contours so we avoid rendering dozens of shapes.
+const MAX_DISPLAY_CONTOURS = 3;
 
 // Grab the upload input and preview container once the page loads.
 const fileInput = document.getElementById(DOM_IDS.input);
@@ -267,7 +269,7 @@ function insertTopContour(list, contour, area, perimeter) {
     list.push(entry);
   }
 
-  if (list.length > 5) {
+  if (list.length > MAX_DISPLAY_CONTOURS) {
     const removed = list.pop();
     removed.mat.delete();
   }


### PR DESCRIPTION
## Summary
- limit the stored contour list to the three largest shapes to avoid heavy rendering
- document the contour cap so future changes understand the constraint

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6010b1e048330a7fdd6e01e0087a5