### PR TITLE
Add STL designer tab with 3D preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,17 +2,251 @@
 <html lang="en">
 <head>
   <script src="https://docs.opencv.org/4.x/opencv.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.161.0/build/three.min.js" defer></script>
   <script src="frontend/scripts.js" defer></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>GridFinium</title>
+  <style>
+    :root {
+      color-scheme: light;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.5;
+      background-color: #f5f6fa;
+      color: #1f2933;
+    }
+
+    body {
+      margin: 0;
+      padding: 24px;
+      display: flex;
+      justify-content: center;
+    }
+
+    main.app {
+      width: min(960px, 100%);
+      background: #ffffff;
+      border-radius: 16px;
+      box-shadow: 0 14px 30px rgba(15, 23, 42, 0.12);
+      padding: 32px clamp(20px, 4vw, 48px);
+    }
+
+    h1 {
+      margin-top: 0;
+      margin-bottom: 24px;
+      font-size: clamp(2rem, 4vw, 2.5rem);
+      text-align: center;
+      letter-spacing: 0.04em;
+    }
+
+    .tab-bar {
+      display: flex;
+      gap: 8px;
+      background: #eef2ff;
+      padding: 6px;
+      border-radius: 999px;
+      margin-bottom: 24px;
+      justify-content: center;
+    }
+
+    .tab-button {
+      border: none;
+      background: transparent;
+      color: #475569;
+      font-weight: 600;
+      padding: 10px 22px;
+      border-radius: 999px;
+      cursor: pointer;
+      transition: background 0.2s ease, color 0.2s ease, transform 0.15s ease;
+    }
+
+    .tab-button:hover {
+      background: rgba(99, 102, 241, 0.16);
+      color: #312e81;
+      transform: translateY(-1px);
+    }
+
+    .tab-button.is-active {
+      background: #4f46e5;
+      color: #ffffff;
+      box-shadow: 0 8px 16px rgba(79, 70, 229, 0.35);
+    }
+
+    .tab-panel {
+      display: none;
+    }
+
+    .tab-panel.is-active {
+      display: block;
+      animation: fade-in 180ms ease;
+    }
+
+    @keyframes fade-in {
+      from {
+        opacity: 0;
+        transform: translateY(4px);
+      }
+
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    section + section {
+      margin-top: 32px;
+    }
+
+    #preview {
+      margin-top: 20px;
+    }
+
+    .stl-grid {
+      display: grid;
+      gap: 16px;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      align-items: start;
+    }
+
+    .stl-form {
+      display: grid;
+      gap: 14px;
+    }
+
+    .stl-form label {
+      display: grid;
+      gap: 6px;
+      font-weight: 600;
+    }
+
+    .stl-form input[type="number"] {
+      border-radius: 10px;
+      border: 1px solid #cbd5f5;
+      padding: 10px 14px;
+      font-size: 1rem;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .stl-form input[type="number"]:focus {
+      outline: none;
+      border-color: #6366f1;
+      box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.25);
+    }
+
+    .stl-actions {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+      margin-top: 8px;
+    }
+
+    .stl-button {
+      border: none;
+      border-radius: 12px;
+      padding: 10px 18px;
+      font-weight: 600;
+      cursor: pointer;
+      background: #4f46e5;
+      color: white;
+      box-shadow: 0 8px 16px rgba(79, 70, 229, 0.25);
+      transition: transform 0.15s ease, box-shadow 0.2s ease;
+    }
+
+    .stl-button:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 12px 20px rgba(79, 70, 229, 0.28);
+    }
+
+    .stl-button.secondary {
+      background: #e0e7ff;
+      color: #312e81;
+      box-shadow: none;
+    }
+
+    .stl-summary {
+      margin: 0;
+      font-size: 0.95rem;
+      color: #475569;
+    }
+
+    .stl-viewer {
+      width: 100%;
+      height: clamp(260px, 40vh, 400px);
+      background: radial-gradient(circle at 30% 30%, #f8fafc, #e2e8f0);
+      border-radius: 16px;
+      position: relative;
+      overflow: hidden;
+      border: 1px solid rgba(148, 163, 184, 0.4);
+    }
+
+    .stl-tip {
+      margin-top: 12px;
+      color: #64748b;
+      font-size: 0.9rem;
+    }
+
+    @media (max-width: 640px) {
+      body {
+        padding: 16px;
+      }
+
+      main.app {
+        padding: 24px 18px;
+      }
+
+      .stl-actions {
+        flex-direction: column;
+      }
+
+      .stl-button {
+        width: 100%;
+        text-align: center;
+      }
+    }
+  </style>
 </head>
 <body>
-  <main>
+  <main class="app">
     <h1>Gridfinium</h1>
-    <h2>1. Upload File</h2>
-    <input type="file" accept=".jpg,.jpeg,.png" id="file-upload" name="file-upload">
-    <div id="preview"></div>
+    <nav class="tab-bar" aria-label="Primary">
+      <button type="button" class="tab-button is-active" data-tab-target="image-tools">Image Tools</button>
+      <button type="button" class="tab-button" data-tab-target="stl-tools">STL Designer</button>
+    </nav>
+
+    <section id="image-tools" class="tab-panel is-active" aria-label="Image Tools">
+      <h2>1. Upload File</h2>
+      <p>Upload a photo to detect and outline documents automatically.</p>
+      <input type="file" accept=".jpg,.jpeg,.png" id="file-upload" name="file-upload">
+      <div id="preview"></div>
+    </section>
+
+    <section id="stl-tools" class="tab-panel" aria-label="STL Designer">
+      <h2>Create &amp; Preview STL Files</h2>
+      <p>Adjust the dimensions of your model in inches, preview it in 3D, and export a ready-to-print STL file.</p>
+      <div class="stl-grid">
+        <form class="stl-form" aria-describedby="stl-summary">
+          <label>
+            Width (X)
+            <input type="number" id="stl-width" name="stl-width" min="0.1" step="0.1" value="4">
+          </label>
+          <label>
+            Depth (Y)
+            <input type="number" id="stl-depth" name="stl-depth" min="0.1" step="0.1" value="6">
+          </label>
+          <label>
+            Height (Z)
+            <input type="number" id="stl-height" name="stl-height" min="0.1" step="0.1" value="3">
+          </label>
+          <p id="stl-summary" class="stl-summary" role="status">Cube dimensions: 4&quot; × 6&quot; × 3&quot;.</p>
+          <div class="stl-actions">
+            <button type="button" class="stl-button" id="stl-download">Download STL</button>
+            <button type="button" class="stl-button secondary" id="stl-reset">Reset to 4&quot; × 6&quot; × 3&quot;</button>
+          </div>
+        </form>
+        <div class="stl-viewer" id="stl-viewer" aria-label="3D preview" role="img"></div>
+      </div>
+      <p class="stl-tip">Tip: drag to rotate the model and use your scroll wheel or trackpad to zoom.</p>
+    </section>
   </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a tabbed layout to the landing page with styling for both tools
- introduce an STL Designer tab that previews a default 4"×6"×3" cube and lets users tweak/export dimensions
- implement Three.js powered viewer, tab switching, and ASCII STL export logic in the frontend script

## Testing
- Manual testing via local http server

------
https://chatgpt.com/codex/tasks/task_e_68d862ac04bc8330a05807141280d804