### PR TITLE
Add resilient Three.js loading for STL viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
   <script src="https://docs.opencv.org/4.x/opencv.js" defer></script>
-  <script src="https://cdn.jsdelivr.net/npm/three@0.161.0/build/three.min.js" defer></script>
   <script src="frontend/scripts.js" defer></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
## Summary
- load Three.js on demand with CDN fallbacks so the STL viewer always initializes
- surface a clear console error and inline message when every source fails
- remove the hard-coded Three.js script tag now that the loader manages dependencies

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d8705008488330bccd9815cdaa1bc2