### PR TITLE
Add canvas fallback renderer for STL preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,6 +178,18 @@
       border: 1px solid rgba(148, 163, 184, 0.4);
     }
 
+    .stl-viewer__canvas {
+      width: 100%;
+      height: 100%;
+      display: block;
+      cursor: grab;
+      touch-action: none;
+    }
+
+    .stl-viewer__canvas:active {
+      cursor: grabbing;
+    }
+
     .stl-tip {
       margin-top: 12px;
       color: #64748b;


### PR DESCRIPTION
## Summary
- add a shared STL designer bootstrap that falls back to a canvas renderer when Three.js cannot be fetched
- refactor the Three.js viewer to use the shared controls and improve pointer handling
- style the STL viewer canvas so the fallback preview fills the allotted space with grab cursors

## Testing
- not run (browser-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d885d11cd48330a26f564297ab4a75