### PR TITLE
Expose paper processing steps and wrap hint tuning controls

### DIFF
--- a/frontend/scripts.js
+++ b/frontend/scripts.js
@@ -25,7 +25,7 @@ const HINT_TUNING_DEFAULTS = Object.freeze({
   cannyHighThreshold: 180,
   kernelSize: 3,
   minAreaRatio: 0.0002,
-  showProcessingSteps: false,
+  showProcessingSteps: true,
 });
 
 const HINT_TUNING_INPUT_IDS = Object.freeze({
@@ -427,14 +427,13 @@ function createStepRenderer(container) {
 
   const section = document.createElement('section');
   section.className = 'processing-steps';
-  section.hidden = true;
 
   const header = document.createElement('div');
   header.className = 'processing-steps__header';
 
   const title = document.createElement('h3');
   title.className = 'processing-steps__title';
-  title.textContent = 'Processing Steps';
+  title.textContent = 'Paper Processing Steps';
 
   const toggle = document.createElement('button');
   toggle.type = 'button';
@@ -506,10 +505,17 @@ function createStepRenderer(container) {
   return {
     renderStep,
     setVisible: (visible) => {
-      section.hidden = !visible;
-      if (visible) {
+      section.hidden = false;
+      toggle.disabled = !visible;
+      section.classList.toggle('processing-steps--disabled', !visible);
+      if (!visible) {
+        expanded = false;
+        list.style.display = 'none';
+      } else {
+        list.style.display = '';
         requestAnimationFrame(syncListStyles);
       }
+      syncToggleState();
     },
     setExpanded: (nextExpanded) => {
       expanded = Boolean(nextExpanded);
@@ -723,6 +729,14 @@ function ensureProcessingStyles() {
     }
     .processing-steps__toggle:hover {
       background: #4338ca;
+    }
+    .processing-steps--disabled .processing-steps__toggle {
+      opacity: 0.6;
+      cursor: not-allowed;
+      background: #9ca3af;
+    }
+    .processing-steps--disabled .processing-steps__toggle:hover {
+      background: #9ca3af;
     }
     .processing-steps__list {
       display: grid;
@@ -1219,11 +1233,40 @@ function setupTabs() {
 }
 
 function setupHintTuningControls() {
+  const tuningContent = document.getElementById('hint-tuning-content');
+  const tuningToggle = document.getElementById('hint-tuning-toggle');
+
   const lowInput = document.getElementById(HINT_TUNING_INPUT_IDS.low);
   const highInput = document.getElementById(HINT_TUNING_INPUT_IDS.high);
   const kernelInput = document.getElementById(HINT_TUNING_INPUT_IDS.kernel);
   const minAreaInput = document.getElementById(HINT_TUNING_INPUT_IDS.minArea);
   const showStepsInput = document.getElementById(HINT_TUNING_INPUT_IDS.showSteps);
+
+  if (tuningContent && tuningToggle) {
+    let tuningExpanded = true;
+
+    const syncTuningContent = () => {
+      tuningContent.dataset.expanded = tuningExpanded ? 'true' : 'false';
+      tuningContent.setAttribute('aria-hidden', String(!tuningExpanded));
+      tuningToggle.setAttribute('aria-expanded', String(tuningExpanded));
+
+      if (tuningExpanded) {
+        tuningContent.style.maxHeight = `${tuningContent.scrollHeight}px`;
+      } else {
+        tuningContent.style.maxHeight = '0px';
+      }
+
+      tuningToggle.textContent = tuningExpanded ? 'Hide details' : 'Show details';
+    };
+
+    tuningToggle.addEventListener('click', () => {
+      tuningExpanded = !tuningExpanded;
+      syncTuningContent();
+    });
+
+    syncTuningContent();
+    requestAnimationFrame(syncTuningContent);
+  }
 
   if (!lowInput || !highInput || !kernelInput || !minAreaInput || !showStepsInput) return;
 

--- a/index.html
+++ b/index.html
@@ -81,22 +81,63 @@
       animation: fade-in 180ms ease;
     }
 
-    .tuning-panel {
+    .hint-tuning-card {
       margin-top: 36px;
-      padding: 20px;
-      border-radius: 16px;
-      border: 1px solid rgba(99, 102, 241, 0.18);
-      background: linear-gradient(135deg, #f8fafc, #eef2ff);
+      border: 1px solid #ddd;
+      border-radius: 12px;
+      background: #ffffff;
       box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+      overflow: hidden;
     }
 
-    .tuning-panel h2 {
-      margin-top: 0;
-      margin-bottom: 12px;
+    .hint-tuning-card__header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 18px 20px;
+      background: linear-gradient(135deg, #eef2ff, #f8fafc);
+      gap: 12px;
+    }
+
+    .hint-tuning-card__title {
+      margin: 0;
       font-size: clamp(1.35rem, 2.5vw, 1.6rem);
     }
 
-    .tuning-panel p {
+    .hint-tuning-card__toggle {
+      border: none;
+      background: #4f46e5;
+      color: #ffffff;
+      padding: 8px 18px;
+      border-radius: 999px;
+      cursor: pointer;
+      font-weight: 600;
+      transition: background 0.2s ease, transform 0.15s ease;
+    }
+
+    .hint-tuning-card__toggle:hover {
+      background: #4338ca;
+      transform: translateY(-1px);
+    }
+
+    .hint-tuning-card__toggle:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+      transform: none;
+    }
+
+    .hint-tuning-card__content {
+      padding: 0 20px;
+      overflow: hidden;
+      max-height: 0;
+      transition: max-height 0.3s ease, padding 0.2s ease;
+    }
+
+    .hint-tuning-card__content[data-expanded="true"] {
+      padding: 20px;
+    }
+
+    .hint-tuning-card__description {
       margin-top: 0;
       margin-bottom: 18px;
       color: #475569;
@@ -303,10 +344,16 @@
       <input type="file" accept=".jpg,.jpeg,.png" id="file-upload" name="file-upload">
       <div id="preview"></div>
 
-      <section class="tuning-panel" aria-labelledby="tuning-heading">
-        <h2 id="tuning-heading">2. Tuning Parameters</h2>
-        <p>Use these sliders to guide hint-based selections toward the object you care about.</p>
-        <div class="tuning-grid" role="group" aria-describedby="tuning-heading">
+      <section class="hint-tuning-card" id="hint-tuning-card" aria-labelledby="tuning-heading">
+        <div class="hint-tuning-card__header">
+          <h2 id="tuning-heading" class="hint-tuning-card__title">2. Hint Tuning Parameters</h2>
+          <button type="button" class="hint-tuning-card__toggle" id="hint-tuning-toggle" aria-controls="hint-tuning-content">
+            Hide details
+          </button>
+        </div>
+        <div id="hint-tuning-content" class="hint-tuning-card__content" data-expanded="true" role="group" aria-describedby="tuning-heading">
+          <p class="hint-tuning-card__description">Use these sliders to guide hint-based selections toward the object you care about.</p>
+          <div class="tuning-grid">
           <div class="tuning-field">
             <label for="hint-threshold-low">Canny low threshold</label>
             <input type="number" id="hint-threshold-low" name="hint-threshold-low" min="0" max="255" step="1">
@@ -328,10 +375,11 @@
             <p class="tuning-note">Ignores shapes below this percentage of the full image. Reduce it to keep petite selections.</p>
           </div>
         </div>
-        <label class="tuning-checkbox" for="hint-show-steps">
-          <input type="checkbox" id="hint-show-steps" name="hint-show-steps">
-          <span>Display processing steps while outlining</span>
-        </label>
+          <label class="tuning-checkbox" for="hint-show-steps">
+            <input type="checkbox" id="hint-show-steps" name="hint-show-steps">
+            <span>Display paper processing steps while outlining</span>
+          </label>
+        </div>
       </section>
     </section>
 


### PR DESCRIPTION
## Summary
- show the paper processing steps panel by default and rename it for clarity
- add disabled styling while the step display is toggled off
- wrap the hint tuning controls in an accordion card similar to the processing steps layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da876f6dd48330881ac1a89dc421aa