### PR TITLE
Align hint tuning card with processing steps

### DIFF
--- a/frontend/scripts.js
+++ b/frontend/scripts.js
@@ -713,9 +713,10 @@ function ensureProcessingStyles() {
       padding: 12px 16px;
       background: linear-gradient(135deg, #eef2ff, #f8fafc);
     }
-    .processing-steps__header h3 {
+    .processing-steps__title {
       margin: 0;
-      font-size: 1rem;
+      font-size: clamp(1.35rem, 2.5vw, 1.6rem);
+      font-weight: 700;
     }
     .processing-steps__toggle {
       border: none;
@@ -1243,7 +1244,7 @@ function setupHintTuningControls() {
   const showStepsInput = document.getElementById(HINT_TUNING_INPUT_IDS.showSteps);
 
   if (tuningContent && tuningToggle) {
-    let tuningExpanded = true;
+    let tuningExpanded = false;
 
     const syncTuningContent = () => {
       tuningContent.dataset.expanded = tuningExpanded ? 'true' : 'false';

--- a/index.html
+++ b/index.html
@@ -99,9 +99,11 @@
       gap: 12px;
     }
 
-    .hint-tuning-card__title {
+    .hint-tuning-card__title,
+    .processing-steps__title {
       margin: 0;
       font-size: clamp(1.35rem, 2.5vw, 1.6rem);
+      font-weight: 700;
     }
 
     .hint-tuning-card__toggle {
@@ -346,12 +348,12 @@
 
       <section class="hint-tuning-card" id="hint-tuning-card" aria-labelledby="tuning-heading">
         <div class="hint-tuning-card__header">
-          <h2 id="tuning-heading" class="hint-tuning-card__title">2. Hint Tuning Parameters</h2>
-          <button type="button" class="hint-tuning-card__toggle" id="hint-tuning-toggle" aria-controls="hint-tuning-content">
-            Hide details
+          <h2 id="tuning-heading" class="hint-tuning-card__title">Hint Tuning Parameters</h2>
+          <button type="button" class="hint-tuning-card__toggle" id="hint-tuning-toggle" aria-controls="hint-tuning-content" aria-expanded="false">
+            Show details
           </button>
         </div>
-        <div id="hint-tuning-content" class="hint-tuning-card__content" data-expanded="true" role="group" aria-describedby="tuning-heading">
+        <div id="hint-tuning-content" class="hint-tuning-card__content" data-expanded="false" role="group" aria-describedby="tuning-heading">
           <p class="hint-tuning-card__description">Use these sliders to guide hint-based selections toward the object you care about.</p>
           <div class="tuning-grid">
           <div class="tuning-field">


### PR DESCRIPTION
## Summary
- match the paper processing steps heading typography with the hint tuning panel title
- remove the numeric prefix from the hint tuning heading and collapse the panel by default so it mirrors the processing steps

## Testing
- Manual UI verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68da9f0e10b08330b71fee5e82cf48d4