### PR TITLE
Auto-expand hint processing steps

### DIFF
--- a/frontend/scripts.js
+++ b/frontend/scripts.js
@@ -123,6 +123,7 @@ async function processImageFromSource(imageSrc) {
   activeHintProcessingSteps = createStepRenderer(previewContainer, {
     titleText: 'Hint Processing Steps',
     hideWhenEmpty: true,
+    startExpanded: true,
   });
   syncProcessingStepsVisibility();
   const renderStep = (label, mat, modifier, renderOptions) => {
@@ -1157,6 +1158,10 @@ function prepareHintStepRenderer() {
   }
 
   activeHintProcessingSteps.setVisible(Boolean(hintTuningState.showProcessingSteps));
+  if (hintTuningState.showProcessingSteps && typeof activeHintProcessingSteps.setExpanded === 'function') {
+    // Automatically expand the panel so the freshly generated hint steps are visible.
+    activeHintProcessingSteps.setExpanded(true);
+  }
 
   return (label, mat, modifier, stepOptions) => {
     activeHintProcessingSteps.renderStep(label, mat, modifier, stepOptions);


### PR DESCRIPTION
## Summary
- ensure the hint processing steps panel starts expanded so generated hints are shown without extra clicks
- automatically re-expand the panel whenever a new hint is produced to surface the latest processing images

## Testing
- Manual verification (Playwright screenshot)


------
https://chatgpt.com/codex/tasks/task_e_68dadfe15ab483308c378de3050f7dea