### PR TITLE
Adjust hint tuning defaults for coaster selection

### DIFF
--- a/frontend/readme.md
+++ b/frontend/readme.md
@@ -119,13 +119,13 @@ flowchart TD
 ### Settings you can tweak
 Several numbers control which contour wins once a hint is supplied:
 
-- **Canny thresholds (60, 180)** decide how strong an edge must be before it is
+- **Canny thresholds (40, 120)** decide how strong an edge must be before it is
   kept. Lower values make the picker more sensitive, which helps highlight
   smaller objects like the coaster at the cost of catching more noise.
-- **Morphology kernel size (3×3)** closes gaps between edge pixels. Increase it
+- **Morphology kernel size (5×5)** closes gaps between edge pixels. Increase it
   to merge nearby edges into one shape, or shrink it to keep neighboring objects
   separate so the coaster does not blend into the surrounding paper.
-- **Minimum contour area (`imageArea × 0.0002`)** filters out tiny fragments.
+- **Minimum contour area (`imageArea × 0.0001`)** filters out tiny fragments.
   Reduce this ratio if the coaster is still ignored, or raise it to focus only
   on large objects such as the sheet of paper.
 

--- a/frontend/scripts.js
+++ b/frontend/scripts.js
@@ -21,10 +21,10 @@ let threeLoaderPromise = null;
 const OVERLAY_COORDINATE_SCALE = 1000;
 
 const HINT_TUNING_DEFAULTS = Object.freeze({
-  cannyLowThreshold: 60,
-  cannyHighThreshold: 180,
-  kernelSize: 3,
-  minAreaRatio: 0.0002,
+  cannyLowThreshold: 40,
+  cannyHighThreshold: 120,
+  kernelSize: 5,
+  minAreaRatio: 0.0001,
   showProcessingSteps: true,
 });
 


### PR DESCRIPTION
## Summary
- lower the default hint Canny thresholds so coaster edges are detected more reliably
- expand the default morphology kernel and relax the minimum area ratio to preserve coaster contours
- document the updated defaults in the frontend guide

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dae0ab14488330abb4416e3123bbd6