### PR TITLE
Keep hint processing steps collapsed by default

### DIFF
--- a/frontend/scripts.js
+++ b/frontend/scripts.js
@@ -123,7 +123,7 @@ async function processImageFromSource(imageSrc) {
   activeHintProcessingSteps = createStepRenderer(previewContainer, {
     titleText: 'Hint Processing Steps',
     hideWhenEmpty: true,
-    startExpanded: true,
+    startExpanded: false,
   });
   syncProcessingStepsVisibility();
   const renderStep = (label, mat, modifier, renderOptions) => {
@@ -1225,10 +1225,6 @@ function prepareHintStepRenderer() {
   }
 
   activeHintProcessingSteps.setVisible(Boolean(hintTuningState.showProcessingSteps));
-  if (hintTuningState.showProcessingSteps && typeof activeHintProcessingSteps.setExpanded === 'function') {
-    // Automatically expand the panel so the freshly generated hint steps are visible.
-    activeHintProcessingSteps.setExpanded(true);
-  }
 
   return (label, mat, modifier, stepOptions) => {
     activeHintProcessingSteps.renderStep(label, mat, modifier, stepOptions);


### PR DESCRIPTION
## Summary
- stop auto-expanding the hint processing steps panel when hints are generated
- ensure the hint processing steps start in a collapsed state

## Testing
- not run (frontend change only)


------
https://chatgpt.com/codex/tasks/task_e_68dbbd5b025c8330bcf1f908441b97a6