### PR TITLE
Prevent selecting contours larger than paper

### DIFF
--- a/frontend/scripts.js
+++ b/frontend/scripts.js
@@ -44,6 +44,7 @@ const MAX_DISPLAY_CONTOURS = 5;
 // Keep preview canvases to a mobile-friendly size so zooming never tries to render
 // the original multi-megapixel image at full resolution.
 const MAX_DISPLAY_DIMENSION = 1280;
+const PERIMETER_COMPARISON_EPSILON = 1e-2;
 let processingStepsIdCounter = 0;
 let hintTuningState = { ...HINT_TUNING_DEFAULTS };
 
@@ -1411,6 +1412,14 @@ function findContourAtPoint(sourceMat, point, showStep, displayInfo, paperOutlin
         : Number.POSITIVE_INFINITY;
 
       if (areaDifference <= paperTolerance && perimeterDifference <= paperTolerance) {
+        contour.delete();
+        continue;
+      }
+
+      if (
+        paperMetrics.perimeter > 0
+        && perimeter + PERIMETER_COMPARISON_EPSILON >= paperMetrics.perimeter
+      ) {
         contour.delete();
         continue;
       }


### PR DESCRIPTION
## Summary
- add a small epsilon constant to compare contour perimeters against the detected paper
- skip hint contours whose perimeter is at least as large as the paper so only smaller shapes can be selected

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dca496a3048330a0c480076d19f83b