### PR TITLE
Reset hint tuning panel to documented defaults

### DIFF
--- a/frontend/readme.md
+++ b/frontend/readme.md
@@ -119,16 +119,16 @@ flowchart TD
 ### Settings you can tweak
 Several numbers control which contour wins once a hint is supplied:
 
-- **Canny thresholds (40, 120)** decide how strong an edge must be before it is
+- **Canny thresholds (10, 50)** decide how strong an edge must be before it is
   kept. Lower values make the picker more sensitive, which helps highlight
   smaller objects like the coaster at the cost of catching more noise.
 - **Morphology kernel size (5×5)** closes gaps between edge pixels. Increase it
   to merge nearby edges into one shape, or shrink it to keep neighboring objects
   separate so the coaster does not blend into the surrounding paper.
-- **Minimum contour area (`imageArea × 0.0001`)** filters out tiny fragments.
+- **Minimum contour area (`imageArea × 0.00001`)** filters out tiny fragments.
   Reduce this ratio if the coaster is still ignored, or raise it to focus only
   on large objects such as the sheet of paper.
-- **Paper similarity tolerance (~5%)** prevents the known paper outline from
+- **Paper similarity tolerance (~10%)** prevents the known paper outline from
   winning the hint search. Increase it if the page still sneaks through, or
   lower it when nearby objects have a similar footprint to the paper.
 

--- a/frontend/scripts.js
+++ b/frontend/scripts.js
@@ -21,11 +21,11 @@ let threeLoaderPromise = null;
 const OVERLAY_COORDINATE_SCALE = 1000;
 
 const HINT_TUNING_DEFAULTS = Object.freeze({
-  cannyLowThreshold: 40,
-  cannyHighThreshold: 120,
+  cannyLowThreshold: 10,
+  cannyHighThreshold: 50,
   kernelSize: 5,
-  minAreaRatio: 0.0001,
-  paperExclusionTolerance: 0.05,
+  minAreaRatio: 0.00001,
+  paperExclusionTolerance: 0.1,
   showProcessingSteps: true,
 });
 
@@ -1749,6 +1749,9 @@ function setupHintTuningControls() {
     showStepsInput.checked = Boolean(hintTuningState.showProcessingSteps);
   };
 
+  // Ensure the live state starts from the published defaults so the UI always
+  // reflects the expected baseline even if earlier sessions tweaked the values.
+  applyHintTuningState({ ...HINT_TUNING_DEFAULTS }, { rerunSelection: false });
   syncInputsFromState();
 
   lowInput.addEventListener('change', () => {

--- a/index.html
+++ b/index.html
@@ -358,32 +358,32 @@
           <div class="tuning-grid">
           <div class="tuning-field">
             <label for="hint-threshold-low">Canny low threshold</label>
-            <input type="number" id="hint-threshold-low" name="hint-threshold-low" min="0" max="255" step="1">
+            <input type="number" id="hint-threshold-low" name="hint-threshold-low" min="0" max="255" step="1" value="10">
             <p class="tuning-note">Lower values pick up faint edges. Raise this if tiny textures cause noisy selections.</p>
           </div>
           <div class="tuning-field">
             <label for="hint-threshold-high">Canny high threshold</label>
-            <input type="number" id="hint-threshold-high" name="hint-threshold-high" min="0" max="255" step="1">
+            <input type="number" id="hint-threshold-high" name="hint-threshold-high" min="0" max="255" step="1" value="50">
             <p class="tuning-note">Higher numbers keep only strong borders. Drop it to help latch onto small items like the coaster.</p>
           </div>
           <div class="tuning-field">
             <label for="hint-kernel-size">Morphology kernel size</label>
-            <input type="number" id="hint-kernel-size" name="hint-kernel-size" min="1" max="31" step="1">
+            <input type="number" id="hint-kernel-size" name="hint-kernel-size" min="1" max="31" step="1" value="5">
             <p class="tuning-note">Controls how aggressively edges are merged. Keep it small to separate nearby shapes.</p>
           </div>
           <div class="tuning-field">
             <label for="hint-min-area">Minimum contour area (%)</label>
-            <input type="number" id="hint-min-area" name="hint-min-area" min="0" max="5" step="0.01">
+            <input type="number" id="hint-min-area" name="hint-min-area" min="0" max="5" step="0.001" value="0.001">
             <p class="tuning-note">Ignores shapes below this percentage of the full image. Reduce it to keep petite selections.</p>
           </div>
           <div class="tuning-field">
             <label for="hint-paper-tolerance">Paper similarity tolerance (%)</label>
-            <input type="number" id="hint-paper-tolerance" name="hint-paper-tolerance" min="0" max="100" step="0.01">
+            <input type="number" id="hint-paper-tolerance" name="hint-paper-tolerance" min="0" max="100" step="0.01" value="10">
             <p class="tuning-note">Reject hint contours whose size is within this percent of the paper outline. Raise it if the paper keeps winning.</p>
           </div>
         </div>
         <label class="tuning-checkbox" for="hint-show-steps">
-          <input type="checkbox" id="hint-show-steps" name="hint-show-steps">
+          <input type="checkbox" id="hint-show-steps" name="hint-show-steps" checked>
           <span>Display paper processing steps while outlining</span>
         </label>
         </div>


### PR DESCRIPTION
## Summary
- ensure the hint tuning state resets to the documented defaults on page load so the sliders open at 10/50 thresholds
- bake the same defaults into the HTML controls to provide the correct fallback values when JavaScript is unavailable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dca3ddc8ac8330af82505f98fbb71a