### PR TITLE
Add toggle for hint erosion step

### DIFF
--- a/index.html
+++ b/index.html
@@ -386,6 +386,10 @@
           <input type="checkbox" id="hint-show-steps" name="hint-show-steps" checked>
           <span>Display paper processing steps while outlining</span>
         </label>
+        <label class="tuning-checkbox" for="hint-enable-erode">
+          <input type="checkbox" id="hint-enable-erode" name="hint-enable-erode" checked>
+          <span>Apply <code>cv.erode()</code> refinement after dilation</span>
+        </label>
         </div>
       </section>
     </section>


### PR DESCRIPTION
## Summary
- add a hint tuning checkbox to toggle the cv.erode refinement step
- propagate the new toggle through the hint selection pipeline and configuration state

## Testing
- Manual QA: Viewed the updated hint tuning controls in the browser

------
https://chatgpt.com/codex/tasks/task_e_68de9436eeb48330b2d40f27d414e4cf