### PR TITLE
Remove sample PNGs from source control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ __pycache__/
 # Logs
 logs/
 *.log
+
+# Frontend sample assets
+frontend/test-images/*.png

--- a/frontend/scripts.js
+++ b/frontend/scripts.js
@@ -4,7 +4,29 @@ const DOM_IDS = {
   preview: 'preview',
 };
 
-const DEFAULT_IMAGE_PATH = 'example_coaster.jpeg';
+const TEST_IMAGES = Object.freeze([
+  {
+    id: 'test-image-mouse',
+    label: 'Mouse on paper',
+    src: 'frontend/test-images/mouse.png',
+  },
+  {
+    id: 'test-image-remote',
+    label: 'Remote on paper',
+    src: 'frontend/test-images/remote.png',
+  },
+  {
+    id: 'test-image-coaster',
+    label: 'Coaster top on paper',
+    src: 'frontend/test-images/coaster-top.png',
+  },
+]);
+
+const TEST_IMAGE_LOOKUP = new Map(TEST_IMAGES.map((image) => [image.id, image]));
+const DEFAULT_PREVIEW_FALLBACK = 'example_coaster.jpeg';
+const DEFAULT_IMAGE_PATH = TEST_IMAGES[0]?.src ?? DEFAULT_PREVIEW_FALLBACK;
+const TEST_IMAGE_PICKER_ID = 'test-image-picker';
+const TEST_IMAGE_BUTTON_ACTIVE_CLASS = 'test-image-button--active';
 
 const TAB_DATA_ATTRIBUTE = 'data-tab-target';
 const STL_DEFAULT_DIMENSIONS = Object.freeze({
@@ -60,13 +82,21 @@ let activePaperProcessingSteps = null;
 let activeHintProcessingSteps = null;
 const overlayStateMap = new WeakMap();
 const overlayResetButtonMap = new WeakMap();
+let testImageButtons = [];
+let activeTestImageId = null;
+
+let defaultPreviewLoaded = false;
 
 // Only hook up the change handler when the key DOM nodes exist.
 if (fileInput && previewContainer) {
   fileInput.addEventListener('change', handleFileSelection);
-  loadDefaultPreview(DEFAULT_IMAGE_PATH);
+  defaultPreviewLoaded = setupTestImagePicker();
 } else {
   console.warn('GridFinium: required DOM elements not found.');
+}
+
+if (!defaultPreviewLoaded) {
+  loadDefaultPreview(DEFAULT_IMAGE_PATH);
 }
 
 setupTabs();
@@ -94,6 +124,8 @@ ensureThreeJs()
 async function handleFileSelection(event) {
   const file = event.target?.files?.[0];
   if (!file) return;
+
+  setActiveTestImage(null);
 
   const objectUrl = URL.createObjectURL(file);
 
@@ -187,6 +219,63 @@ async function processImageFromSource(imageSrc) {
   }
 }
 
+// Build the toggle buttons that let users try the bundled sample photos.
+function setupTestImagePicker() {
+  const picker = document.getElementById(TEST_IMAGE_PICKER_ID);
+  if (!picker) return false;
+
+  const buttons = Array.from(picker.querySelectorAll('[data-test-image-id]'));
+  if (buttons.length === 0) return false;
+
+  testImageButtons = buttons;
+
+  buttons.forEach((button) => {
+    const imageId = button.getAttribute('data-test-image-id');
+    const testImage = TEST_IMAGE_LOOKUP.get(imageId);
+
+    button.type = 'button';
+    button.setAttribute('aria-pressed', 'false');
+
+    if (!testImage) {
+      button.disabled = true;
+      button.setAttribute('aria-disabled', 'true');
+      return;
+    }
+
+    button.addEventListener('click', () => {
+      if (activeTestImageId === imageId) return;
+
+      setActiveTestImage(imageId);
+      if (fileInput) {
+        fileInput.value = '';
+      }
+      loadDefaultPreview(testImage.src);
+    });
+  });
+
+  const defaultImage = TEST_IMAGES[0];
+  if (defaultImage) {
+    setActiveTestImage(defaultImage.id);
+    loadDefaultPreview(defaultImage.src);
+    return true;
+  }
+
+  return false;
+}
+
+// Highlight the active sample image button and reset when uploads occur.
+function setActiveTestImage(testImageId) {
+  activeTestImageId = testImageId;
+
+  if (!testImageButtons.length) return;
+
+  testImageButtons.forEach((button) => {
+    const isActive = button.getAttribute('data-test-image-id') === testImageId;
+    button.classList.toggle(TEST_IMAGE_BUTTON_ACTIVE_CLASS, isActive);
+    button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+  });
+}
+
 function createPreviewResultSection(container) {
   ensureProcessingStyles();
 
@@ -237,6 +326,18 @@ function createPreviewResultSection(container) {
 function loadDefaultPreview(imageSrc) {
   processImageFromSource(imageSrc).catch((error) => {
     console.error('GridFinium: failed to load default preview image.', error);
+
+    if (imageSrc === DEFAULT_PREVIEW_FALLBACK) {
+      return;
+    }
+
+    if (activeTestImageId) {
+      setActiveTestImage(null);
+    }
+
+    processImageFromSource(DEFAULT_PREVIEW_FALLBACK).catch((fallbackError) => {
+      console.error('GridFinium: failed to load fallback preview image.', fallbackError);
+    });
   });
 }
 

--- a/frontend/test-images/README.md
+++ b/frontend/test-images/README.md
@@ -1,0 +1,11 @@
+# Sample image placeholders
+
+This directory is intended to contain the optional sample photos that power the "Sample" buttons in the Image Tools panel. The PNG files are not checked into source control so that the pull request remains free of binary assets.
+
+To use the bundled sample buttons locally, add the following files:
+
+- `mouse.png`
+- `remote.png`
+- `coaster-top.png`
+
+Any PNG image with the matching filename will work. Reload the page after placing the files and the toggle buttons will load the corresponding sample.

--- a/index.html
+++ b/index.html
@@ -122,6 +122,68 @@
       transform: translateY(-1px);
     }
 
+    .test-image-picker {
+      margin-top: 28px;
+      padding: 20px clamp(16px, 4vw, 24px);
+      border-radius: 16px;
+      border: 1px dashed #cbd5f5;
+      background: linear-gradient(135deg, #f8faff, #eef2ff);
+    }
+
+    .test-image-picker__intro {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .test-image-picker__heading {
+      margin: 0;
+      font-size: clamp(1.4rem, 3vw, 1.6rem);
+    }
+
+    .test-image-picker__description {
+      margin: 0;
+      color: #475569;
+      font-size: 0.95rem;
+      max-width: 62ch;
+    }
+
+    .test-image-picker__buttons {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-top: 18px;
+    }
+
+    .test-image-button {
+      border: 1px solid #cbd5f5;
+      background: #ffffff;
+      color: #1f2933;
+      padding: 10px 20px;
+      border-radius: 12px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease;
+    }
+
+    .test-image-button:hover {
+      background: rgba(99, 102, 241, 0.12);
+      color: #312e81;
+      transform: translateY(-1px);
+    }
+
+    .test-image-button:focus-visible {
+      outline: 2px solid #4f46e5;
+      outline-offset: 2px;
+    }
+
+    .test-image-button--active {
+      background: #4f46e5;
+      color: #ffffff;
+      border-color: #4f46e5;
+      box-shadow: 0 10px 24px rgba(79, 70, 229, 0.25);
+    }
+
     .hint-tuning-card__toggle:disabled {
       opacity: 0.6;
       cursor: not-allowed;
@@ -341,6 +403,18 @@
     </nav>
 
     <section id="image-tools" class="tab-panel is-active" aria-label="Image Tools">
+      <section class="test-image-picker" aria-labelledby="test-image-heading">
+        <div class="test-image-picker__intro">
+          <h2 id="test-image-heading" class="test-image-picker__heading">Sample</h2>
+          <p class="test-image-picker__description">Switch between the built-in test photos to see how the workflow responds. Uploading your own image will replace these samples.</p>
+        </div>
+        <div class="test-image-picker__buttons" id="test-image-picker" role="group" aria-label="Sample photos">
+          <button class="test-image-button" data-test-image-id="test-image-mouse">Mouse on paper</button>
+          <button class="test-image-button" data-test-image-id="test-image-remote">Remote on paper</button>
+          <button class="test-image-button" data-test-image-id="test-image-coaster">Coaster top on paper</button>
+        </div>
+      </section>
+
       <h2>1. Upload File</h2>
       <p>Upload a photo to detect and outline documents automatically.</p>
       <input type="file" accept=".jpg,.jpeg,.png" id="file-upload" name="file-upload">


### PR DESCRIPTION
## Summary
- remove the bundled sample PNG assets from the repository so the PR is binary-free
- document the expected sample filenames and how to add them locally
- ignore future sample PNGs and fall back to the built-in coaster preview if a sample image is missing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de94b7e738833095fcaef9a2310a1e