### PR TITLE
Restyle theme toggle switch

### DIFF
--- a/frontend/scripts.js
+++ b/frontend/scripts.js
@@ -108,6 +108,7 @@ if (!defaultPreviewLoaded) {
 
 setupTabs();
 setupHintTuningControls();
+setupThemeToggle();
 
 const stlDesignerOptions = {
   viewerId: 'stl-viewer',
@@ -137,22 +138,11 @@ function setupThemeToggle() {
 
   const applyTheme = (theme) => {
     const normalizedTheme = theme === COLOR_THEMES.DARK ? COLOR_THEMES.DARK : COLOR_THEMES.LIGHT;
+    const isDark = normalizedTheme === COLOR_THEMES.DARK;
     rootElement.setAttribute('data-theme', normalizedTheme);
-    themeToggleButton.setAttribute('aria-pressed', String(normalizedTheme === COLOR_THEMES.DARK));
-    themeToggleButton.setAttribute(
-      'aria-label',
-      normalizedTheme === COLOR_THEMES.DARK ? 'Switch to light mode' : 'Switch to dark mode',
-    );
-
-    const icon = themeToggleButton.querySelector('.theme-toggle__icon');
-    const label = themeToggleButton.querySelector('.theme-toggle__label');
-    if (icon) {
-      icon.textContent = normalizedTheme === COLOR_THEMES.DARK ? '🌙' : '🌞';
-    }
-
-    if (label) {
-      label.textContent = normalizedTheme === COLOR_THEMES.DARK ? 'Dark mode' : 'Light mode';
-    }
+    themeToggleButton.setAttribute('aria-pressed', String(isDark));
+    themeToggleButton.setAttribute('aria-label', isDark ? 'Switch to light mode' : 'Switch to dark mode');
+    themeToggleButton.classList.toggle('theme-toggle--dark', isDark);
   };
 
   const storedTheme = localStorage.getItem(COLOR_THEME_STORAGE_KEY);

--- a/index.html
+++ b/index.html
@@ -111,22 +111,25 @@
     }
 
     .theme-toggle {
+      --toggle-width: 58px;
+      --toggle-height: 30px;
       border: 1px solid var(--color-border-soft);
       background: var(--color-surface-subtle);
-      color: var(--color-body-text);
-      border-radius: 999px;
+      color: var(--color-muted-text);
+      border-radius: var(--toggle-height);
       display: inline-flex;
       align-items: center;
-      gap: 8px;
-      padding: 6px 16px;
+      justify-content: space-between;
+      padding: 0 12px;
+      width: var(--toggle-width);
+      height: var(--toggle-height);
+      position: relative;
       cursor: pointer;
-      font-weight: 600;
-      transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.15s ease;
+      transition: background-color 0.25s ease, border-color 0.25s ease, color 0.25s ease, box-shadow 0.2s ease;
     }
 
     .theme-toggle:hover,
     .theme-toggle:focus-visible {
-      transform: translateY(-1px);
       border-color: var(--color-border-strong);
     }
 
@@ -136,8 +139,42 @@
     }
 
     .theme-toggle__icon {
-      font-size: 1.1rem;
+      font-size: 1.05rem;
       line-height: 1;
+      opacity: 0.55;
+      transition: opacity 0.2s ease, color 0.2s ease;
+      pointer-events: none;
+    }
+
+    .theme-toggle__thumb {
+      position: absolute;
+      top: 3px;
+      left: 3px;
+      width: calc(var(--toggle-height) - 6px);
+      height: calc(var(--toggle-height) - 6px);
+      border-radius: 999px;
+      background: var(--color-surface);
+      box-shadow: 0 6px 12px rgba(15, 23, 42, 0.18);
+      transition: transform 0.25s ease, background-color 0.25s ease, box-shadow 0.25s ease;
+      transform: translateX(0);
+      pointer-events: none;
+    }
+
+    .theme-toggle--dark {
+      background: rgba(99, 102, 241, 0.18);
+      color: var(--color-accent);
+    }
+
+    .theme-toggle--dark .theme-toggle__thumb {
+      transform: translateX(calc(var(--toggle-width) - var(--toggle-height)));
+      background: var(--color-accent);
+      box-shadow: 0 8px 16px rgba(79, 70, 229, 0.35);
+    }
+
+    .theme-toggle--dark .theme-toggle__icon--moon,
+    .theme-toggle:not(.theme-toggle--dark) .theme-toggle__icon--sun {
+      opacity: 1;
+      color: var(--color-body-text);
     }
 
     .tab-bar {
@@ -525,9 +562,10 @@
   <main class="app">
     <header class="app-header">
       <h1 class="app-title">Gridfinium</h1>
-      <button type="button" class="theme-toggle" id="theme-toggle" aria-pressed="false">
-        <span class="theme-toggle__icon" aria-hidden="true">🌞</span>
-        <span class="theme-toggle__label">Light mode</span>
+      <button type="button" class="theme-toggle" id="theme-toggle" aria-pressed="false" aria-label="Switch to dark mode">
+        <span class="theme-toggle__icon theme-toggle__icon--sun" aria-hidden="true">🌞</span>
+        <span class="theme-toggle__thumb" aria-hidden="true"></span>
+        <span class="theme-toggle__icon theme-toggle__icon--moon" aria-hidden="true">🌙</span>
       </button>
     </header>
     <nav class="tab-bar" aria-label="Primary">


### PR DESCRIPTION
## Summary
- restyle the light/dark theme control as a minimal toggle switch with dedicated thumb and icon states
- update theme toggle logic to apply class-based styling and ensure initialization runs on load

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df397975608330ac27456392563087