### PR TITLE
Replace theme toggle emojis with text labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,8 +111,8 @@
     }
 
     .theme-toggle {
-      --toggle-width: 58px;
-      --toggle-height: 30px;
+      --toggle-width: 120px;
+      --toggle-height: 32px;
       border: 1px solid var(--color-border-soft);
       background: var(--color-surface-subtle);
       color: var(--color-muted-text);
@@ -120,12 +120,16 @@
       display: inline-flex;
       align-items: center;
       justify-content: space-between;
-      padding: 0 12px;
+      padding: 0 16px;
       width: var(--toggle-width);
       height: var(--toggle-height);
       position: relative;
       cursor: pointer;
       transition: background-color 0.25s ease, border-color 0.25s ease, color 0.25s ease, box-shadow 0.2s ease;
+      font-size: 0.75rem;
+      font-weight: 600;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
     }
 
     .theme-toggle:hover,
@@ -138,10 +142,9 @@
       box-shadow: 0 0 0 3px var(--color-focus-outline);
     }
 
-    .theme-toggle__icon {
-      font-size: 1.05rem;
+    .theme-toggle__label {
       line-height: 1;
-      opacity: 0.55;
+      opacity: 0.45;
       transition: opacity 0.2s ease, color 0.2s ease;
       pointer-events: none;
     }
@@ -171,8 +174,8 @@
       box-shadow: 0 8px 16px rgba(79, 70, 229, 0.35);
     }
 
-    .theme-toggle--dark .theme-toggle__icon--moon,
-    .theme-toggle:not(.theme-toggle--dark) .theme-toggle__icon--sun {
+    .theme-toggle--dark .theme-toggle__label--dark,
+    .theme-toggle:not(.theme-toggle--dark) .theme-toggle__label--light {
       opacity: 1;
       color: var(--color-body-text);
     }
@@ -563,9 +566,9 @@
     <header class="app-header">
       <h1 class="app-title">Gridfinium</h1>
       <button type="button" class="theme-toggle" id="theme-toggle" aria-pressed="false" aria-label="Switch to dark mode">
-        <span class="theme-toggle__icon theme-toggle__icon--sun" aria-hidden="true">🌞</span>
+        <span class="theme-toggle__label theme-toggle__label--light">Light</span>
         <span class="theme-toggle__thumb" aria-hidden="true"></span>
-        <span class="theme-toggle__icon theme-toggle__icon--moon" aria-hidden="true">🌙</span>
+        <span class="theme-toggle__label theme-toggle__label--dark">Dark</span>
       </button>
     </header>
     <nav class="tab-bar" aria-label="Primary">


### PR DESCRIPTION
## Summary
- replace the theme toggle icons with light/dark text labels for improved clarity
- tune the toggle styling to suit the new text labels while keeping the same interaction behavior

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df3ce3056c833088e401bd525a1ca0