### PR TITLE
Fix hint pixel assignment in overlay click handler

### DIFF
--- a/frontend/scripts.js
+++ b/frontend/scripts.js
@@ -1203,7 +1203,7 @@ function handleOverlayClick(event) {
     y: clamp(Math.round(displayY * scaleY), 0, Math.max(0, originalHeight - 1)),
   };
 
-  state.lastHintPixel = { ...targetPoint };
+  state.lastHintPixel = targetPoint;
   runHintSelection(state);
 }
 


### PR DESCRIPTION
## Summary
- ensure the overlay click handler stores the computed target point directly
- allow the subsequent hint selection routine to use the intended pixel coordinates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df4365a7e48330be1f3f79cdd3e3ab