### PR TITLE
Fix Canny edge handling and caption

### DIFF
--- a/frontend/scripts.js
+++ b/frontend/scripts.js
@@ -1546,7 +1546,9 @@ function findContourAtPoint(sourceMat, point, showStep, displayInfo, paperOutlin
     }
   }
 
-  const edges = new cv.Mat();
+  let edges = null;
+  let cannyLow = tuning.cannyLowThreshold;
+  let cannyHigh = tuning.cannyHighThreshold;
   // When users drop a hint we do a separate pass to highlight the shape around
   // that point. The thresholds and morphology settings are sourced from the
   // interactive tuning panel so you can steer which edges survive long enough


### PR DESCRIPTION
## Summary
- prevent const reassignment when building the Canny edge map by deferring Mat allocation
- show the actual low/high thresholds used in the Canny caption, including auto-calculated values

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df4924aa188330ba32338af13926a8