### PR TITLE
Guard threshold Mats cleanup

### DIFF
--- a/frontend/scripts.js
+++ b/frontend/scripts.js
@@ -1752,7 +1752,10 @@ function findContourAtPoint(sourceMat, point, showStep, displayInfo, paperOutlin
 
   gray.delete();
   blurred.delete();
-  if (bin) bin.delete();
+  if (bin) {
+    bin.delete();
+    bin = null;
+  }
   edges.delete();
   contours.delete();
   hierarchy.delete();


### PR DESCRIPTION
## Summary
- guard threshold Mats so we only delete the binary Mat when it exists and clear the reference afterward to prevent leaks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df4a053e7c8330a0208cb1c0dfde6a