### PR TITLE
Adjust hint mask cleanup handling

### DIFF
--- a/frontend/scripts.js
+++ b/frontend/scripts.js
@@ -1453,10 +1453,10 @@ function findContourAtPoint(sourceMat, point, showStep, displayInfo, paperOutlin
 
   if (normalizedPaperOutline) {
     const masked = buildMaskedDisplayMat(sourceMat, normalizedPaperOutline, displayInfo);
-    if (masked) {
+    if (masked?.mat) {
       workingSource = masked.mat;
-      cleanupWorkingSource = masked.cleanup;
     }
+    cleanupWorkingSource = masked?.cleanup || null;
   }
 
   if (renderStep) {


### PR DESCRIPTION
## Summary
- ensure the masked hint source only registers a cleanup callback when the mask exists

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df4b9e76008330bfd003cc06dd2455