### PR TITLE
Add hint fusion mode controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -658,6 +658,16 @@
             <p class="tuning-note">Ignores shapes below this percentage of the full image. Reduce it to keep petite selections.</p>
           </div>
           <div class="tuning-field">
+            <label for="hint-fusion-mode">Edge/threshold fusion</label>
+            <select id="hint-fusion-mode" name="hint-fusion-mode">
+              <option value="edge">Edge only</option>
+              <option value="threshold">Threshold only</option>
+              <option value="and">Edge AND Threshold</option>
+              <option value="or">Edge OR Threshold</option>
+            </select>
+            <p class="tuning-note">Choose how edge and threshold maps combine when building hint contours.</p>
+          </div>
+          <div class="tuning-field">
             <label for="hint-paper-tolerance">Paper similarity tolerance (%)</label>
             <input type="number" id="hint-paper-tolerance" name="hint-paper-tolerance" min="0" max="100" step="0.01" value="10">
             <p class="tuning-note">Reject hint contours whose size is within this percent of the paper outline. Raise it if the paper keeps winning.</p>


### PR DESCRIPTION
## Summary
- extend hint tuning defaults and normalization with a fusion mode option
- expose a selector in the tuning UI for choosing edge/threshold/AND/OR fusion
- compute and log edge, threshold, and fused maps when finding hint contours

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dfd5f51a388330babc6077c38864e3