### PR TITLE
Extract paper outlining module

### DIFF
--- a/frontend/js/MainScript.js
+++ b/frontend/js/MainScript.js
@@ -1,5 +1,6 @@
 import { bootGridFinium } from '../scripts.js';
+import { detectPaperContour, extractContourPoints } from './PaperOutlining.js';
 
-bootGridFinium();
+bootGridFinium({ detectPaperContour, extractContourPoints });
 
 console.log('GridFinium MainScript: booted');

--- a/frontend/js/PaperOutlining.js
+++ b/frontend/js/PaperOutlining.js
@@ -1,0 +1,121 @@
+const MAX_DISPLAY_CONTOURS = 5;
+
+function insertTopContour(list, contour, area, perimeter) {
+  const clone = contour.clone();
+  const entry = { mat: clone, area, perimeter };
+  let inserted = false;
+
+  for (let i = 0; i < list.length; i += 1) {
+    if (area > list[i].area) {
+      list.splice(i, 0, entry);
+      inserted = true;
+      break;
+    }
+  }
+
+  if (!inserted) {
+    list.push(entry);
+  }
+
+  if (list.length > MAX_DISPLAY_CONTOURS) {
+    const removed = list.pop();
+    removed.mat.delete();
+  }
+}
+
+export function detectPaperContour(src, showStep) {
+  // Step 1: create helper mats that will hold grayscale, blur, and edge data.
+  const gray = new cv.Mat();
+  const blurred = new cv.Mat();
+  const edges = new cv.Mat();
+  const contours = new cv.MatVector();
+  const hierarchy = new cv.Mat();
+
+  // Step 1a: grayscale image so color changes do not distract the edge detector.
+  cv.cvtColor(src, gray, cv.COLOR_RGBA2GRAY);
+  showStep('Grayscale - cv.cvtColor()', gray, 'step-gray');
+  // Step 1b: blur slightly to hide tiny specks of noise.
+  cv.GaussianBlur(gray, blurred, new cv.Size(5, 5), 0);
+  showStep('Blurred - cv.GaussianBlur()', blurred, 'step-blurred');
+  // Step 1c: highlight strong edges that could form the paper outline.
+  cv.Canny(blurred, edges, 30, 90);
+  showStep('Edge Map - cv.Canny()', edges, 'step-edges-raw');
+
+  // Step 1d: morphological cleanup pass to close gaps in the paper outline.
+  const kernel = cv.Mat.ones(5, 5, cv.CV_8U);
+  // Step 1d-i: inflate (dilate) the edges so breaks get filled in.
+  cv.dilate(edges, edges, kernel);
+  showStep('Dilated Edges - cv.dilate()', edges, 'step-edges-dilated');
+  // Step 1d-ii: shrink (erode) them back down so the line is narrow again.
+  // cv.erode(edges, edges, kernel);
+  kernel.delete();
+  // showStep('Cleaned Edges - cv.erode()', edges, 'step-edges-cleaned');
+
+  // Step 2: collect every outline the algorithm discovers.
+  cv.findContours(edges, contours, hierarchy, cv.RETR_LIST, cv.CHAIN_APPROX_SIMPLE);
+
+  const minArea = src.rows * src.cols * 0.15;
+  const topContours = [];
+  let paper = null;
+  let bestArea = 0;
+
+  for (let i = 0; i < contours.size(); i += 1) {
+    const contour = contours.get(i);
+    const perimeter = cv.arcLength(contour, true);
+
+    if (perimeter < 100) {
+      // Skip shapes that are too small to be the sheet.
+      contour.delete();
+      continue;
+    }
+
+    const area = cv.contourArea(contour);
+
+    insertTopContour(topContours, contour, area, perimeter);
+
+    const approx = new cv.Mat();
+    cv.approxPolyDP(contour, approx, 0.02 * perimeter, true);
+
+    const approxArea = cv.contourArea(approx);
+    if (approx.rows === 4 && approxArea > bestArea && approxArea > minArea) {
+      // Step 3: keep the largest four-sided shape we have seen so far.
+      bestArea = approxArea;
+      if (paper) paper.delete();
+      paper = approx;
+    } else {
+      approx.delete();
+    }
+
+    contour.delete();
+  }
+
+  topContours.forEach((entry, index) => {
+    const display = cv.Mat.zeros(src.rows, src.cols, cv.CV_8UC3);
+    const single = new cv.MatVector();
+    single.push_back(entry.mat);
+    cv.drawContours(display, single, -1, new cv.Scalar(255, 87, 34, 255), 2, cv.LINE_AA);
+    single.delete();
+    const caption = `Top Contour ${index + 1}\nPerimeter: ${entry.perimeter.toFixed(1)} px\nArea: ${entry.area.toFixed(1)} px²`;
+    showStep(caption, display, 'step-contour');
+    display.delete();
+    entry.mat.delete();
+  });
+
+  gray.delete();
+  blurred.delete();
+  edges.delete();
+  contours.delete();
+  hierarchy.delete();
+
+  // Return the chosen contour (or null) so the caller can decide what to draw.
+  return paper;
+}
+
+export function extractContourPoints(contour) {
+  const data = contour.data32S;
+  const points = [];
+  for (let i = 0; i < data.length; i += 2) {
+    points.push({ x: data[i], y: data[i + 1] });
+  }
+  return points;
+}

--- a/frontend/scripts.js
+++ b/frontend/scripts.js
@@ -99,8 +99,22 @@ const overlayResetControlMap = new WeakMap();
 let testImageButtons = [];
 let activeTestImageId = null;
 let defaultPreviewLoaded = false;
+let detectPaperContourImpl = null;
+let extractContourPointsImpl = null;
 
-export function bootGridFinium() {
+export function bootGridFinium(dependencies = {}) {
+  const {
+    detectPaperContour: detectPaperContourDependency,
+    extractContourPoints: extractContourPointsDependency,
+  } = dependencies;
+
+  detectPaperContourImpl = typeof detectPaperContourDependency === 'function'
+    ? detectPaperContourDependency
+    : null;
+  extractContourPointsImpl = typeof extractContourPointsDependency === 'function'
+    ? extractContourPointsDependency
+    : null;
+
   fileInput = document.getElementById(DOM_IDS.input);
   previewContainer = document.getElementById(DOM_IDS.preview);
   cvReady = waitForOpenCv();
@@ -274,13 +288,17 @@ async function processImageFromSource(imageSrc) {
   try {
     renderStep('Original Photo', src, 'step-original');
 
-    const paperContour = detectPaperContour(src, renderStep);
+    const paperContour = detectPaperContourImpl
+      ? detectPaperContourImpl(src, renderStep)
+      : null;
 
     let finalDisplay = src;
     let finalOptions;
 
     if (paperContour) {
-      const corners = extractContourPoints(paperContour);
+      const corners = extractContourPointsImpl
+        ? extractContourPointsImpl(paperContour)
+        : [];
       finalDisplay = src.clone();
       const outline = new cv.MatVector();
       outline.push_back(paperContour);
@@ -560,93 +578,6 @@ function initStlDesigner(options) {
   return initCanvasStlDesigner(options);
 }
 
-function detectPaperContour(src, showStep) {
-  // Step 1: create helper mats that will hold grayscale, blur, and edge data.
-  const gray = new cv.Mat();
-  const blurred = new cv.Mat();
-  const edges = new cv.Mat();
-  const contours = new cv.MatVector();
-  const hierarchy = new cv.Mat();
-
-  // Step 1a: grayscale image so color changes do not distract the edge detector.
-  cv.cvtColor(src, gray, cv.COLOR_RGBA2GRAY);
-  showStep('Grayscale - cv.cvtColor()', gray, 'step-gray');
-  // Step 1b: blur slightly to hide tiny specks of noise.
-  cv.GaussianBlur(gray, blurred, new cv.Size(5, 5), 0);
-  showStep('Blurred - cv.GaussianBlur()', blurred, 'step-blurred');
-  // Step 1c: highlight strong edges that could form the paper outline.
-  cv.Canny(blurred, edges, 30, 90);
-  showStep('Edge Map - cv.Canny()', edges, 'step-edges-raw');
-
-  // Step 1d: morphological cleanup pass to close gaps in the paper outline.
-  const kernel = cv.Mat.ones(5, 5, cv.CV_8U);
-  // Step 1d-i: inflate (dilate) the edges so breaks get filled in.
-  cv.dilate(edges, edges, kernel);
-  showStep('Dilated Edges - cv.dilate()', edges, 'step-edges-dilated');
-  // Step 1d-ii: shrink (erode) them back down so the line is narrow again.
-  // cv.erode(edges, edges, kernel);
-  kernel.delete();
-  // showStep('Cleaned Edges - cv.erode()', edges, 'step-edges-cleaned');
-
-  // Step 2: collect every outline the algorithm discovers.
-  cv.findContours(edges, contours, hierarchy, cv.RETR_LIST, cv.CHAIN_APPROX_SIMPLE);
-
-  const minArea = src.rows * src.cols * 0.15;
-  const topContours = [];
-  let paper = null;
-  let bestArea = 0;
-
-  for (let i = 0; i < contours.size(); i += 1) {
-    const contour = contours.get(i);
-    const perimeter = cv.arcLength(contour, true);
-
-    if (perimeter < 100) {
-      // Skip shapes that are too small to be the sheet.
-      contour.delete();
-      continue;
-    }
-
-    const area = cv.contourArea(contour);
-
-    insertTopContour(topContours, contour, area, perimeter);
-
-    const approx = new cv.Mat();
-    cv.approxPolyDP(contour, approx, 0.02 * perimeter, true);
-
-    const approxArea = cv.contourArea(approx);
-    if (approx.rows === 4 && approxArea > bestArea && approxArea > minArea) {
-      // Step 3: keep the largest four-sided shape we have seen so far.
-      bestArea = approxArea;
-      if (paper) paper.delete();
-      paper = approx;
-    } else {
-      approx.delete();
-    }
-
-    contour.delete();
-  }
-
-  topContours.forEach((entry, index) => {
-    const display = cv.Mat.zeros(src.rows, src.cols, cv.CV_8UC3);
-    const single = new cv.MatVector();
-    single.push_back(entry.mat);
-    cv.drawContours(display, single, -1, new cv.Scalar(255, 87, 34, 255), 2, cv.LINE_AA);
-    single.delete();
-    const caption = `Top Contour ${index + 1}\nPerimeter: ${entry.perimeter.toFixed(1)} px\nArea: ${entry.area.toFixed(1)} px²`;
-    showStep(caption, display, 'step-contour');
-    display.delete();
-    entry.mat.delete();
-  });
-
-  gray.delete();
-  blurred.delete();
-  edges.delete();
-  contours.delete();
-  hierarchy.delete();
-
-  // Return the chosen contour (or null) so the caller can decide what to draw.
-  return paper;
-}
 
 function createStepRenderer(container, options = {}) {
   ensureProcessingStyles();
@@ -1093,15 +1024,6 @@ function ensureProcessingStyles() {
     .processing-step.step-hint-selection .processing-canvas { border-color: #ec4899; }
   `;
   document.head.appendChild(style);
-}
-
-function extractContourPoints(contour) {
-  const data = contour.data32S;
-  const points = [];
-  for (let i = 0; i < data.length; i += 2) {
-    points.push({ x: data[i], y: data[i + 1] });
-  }
-  return points;
 }
 
 function attachPaperOverlay(overlay, corners, renderInfo) {


### PR DESCRIPTION
## Summary
- move the paper contour detection and point extraction helpers into a dedicated PaperOutlining module
- inject the paper detection utilities via MainScript so the main bootstrapper consumes the new module without leaking globals

## Testing
- Manual: Loaded http://127.0.0.1:8000/index.html

------
https://chatgpt.com/codex/tasks/task_e_68e04da4a57c8330b81138efd6cc26d3