### PR TITLE
Set Edge AND Threshold as default fusion mode

### DIFF
--- a/frontend/js/ObjectOutlining.js
+++ b/frontend/js/ObjectOutlining.js
@@ -18,7 +18,7 @@ export const HINT_TUNING_DEFAULTS = Object.freeze({
   thresholdMode: 'otsu', // 'otsu' | 'adaptive'
   morphCloseSize: 3,
   morphOpenSize: 3,
-  fusionMode: 'edge', // 'edge' | 'threshold' | 'and' | 'or'
+  fusionMode: 'and', // 'edge' | 'threshold' | 'and' | 'or'
 });
 
 let hintTuningState = { ...HINT_TUNING_DEFAULTS };

--- a/index.html
+++ b/index.html
@@ -662,7 +662,7 @@
             <select id="hint-fusion-mode" name="hint-fusion-mode">
               <option value="edge">Edge only</option>
               <option value="threshold">Threshold only</option>
-              <option value="and">Edge AND Threshold</option>
+              <option value="and" selected>Edge AND Threshold</option>
               <option value="or">Edge OR Threshold</option>
             </select>
             <p class="tuning-note">Choose how edge and threshold maps combine when building hint contours.</p>


### PR DESCRIPTION
## Summary
- default the hint fusion dropdown to Edge AND Threshold in the UI
- align the hint tuning defaults with the new fusion selection

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e119fe4d8083309e2fea3b1e1bd39a