### PR TITLE
Adjust processing panels default expansion states

### DIFF
--- a/frontend/js/MainScript.js
+++ b/frontend/js/MainScript.js
@@ -201,12 +201,15 @@ async function processImageFromSource(imageSrc) {
   } = createPreviewResultSection(previewContainer);
 
   const imageElement = new Image();
-  const paperSteps = createStepRenderer(previewContainer, { titleText: 'Paper Processing Steps' });
+  const paperSteps = createStepRenderer(previewContainer, {
+    titleText: 'Paper Processing Steps',
+    startExpanded: false,
+  });
   activePaperProcessingSteps = paperSteps;
   activeHintProcessingSteps = createStepRenderer(previewContainer, {
     titleText: 'Hint Processing Steps',
     hideWhenEmpty: true,
-    startExpanded: false,
+    startExpanded: true,
   });
   setHintProcessingStepsRenderer(activeHintProcessingSteps);
   syncProcessingStepsVisibility();
@@ -625,12 +628,12 @@ function syncProcessingStepsVisibility() {
   const shouldShowHintSteps = Boolean(hintConfig.showProcessingSteps);
 
   if (activePaperProcessingSteps) {
-    activePaperProcessingSteps.setExpanded(true);
+    activePaperProcessingSteps.setExpanded(false);
     activePaperProcessingSteps.setVisible(true);
   }
 
   if (activeHintProcessingSteps) {
-    activeHintProcessingSteps.setExpanded(false);
+    activeHintProcessingSteps.setExpanded(true);
     activeHintProcessingSteps.setVisible(shouldShowHintSteps);
   }
 }


### PR DESCRIPTION
## Summary
- collapse the paper processing step panel by default
- keep the hint processing step panel expanded when it is visible

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e11a62a25c83309f51f187bc286d0f