### PR TITLE
Restart: simplified paper+object detection page

### DIFF
--- a/frontend/js/MainScript.js
+++ b/frontend/js/MainScript.js
@@ -1,1311 +1,344 @@
 import { detectPaperContour, extractContourPoints } from './PaperOutlining.js';
-import {
-  HINT_TUNING_DEFAULTS,
-  setActiveImageMat,
-  setHintProcessingStepsRenderer,
-  attachPaperOverlay,
-  applyHintTuningState,
-  getHintTuningConfig,
-  OVERLAY_INTERACTION_MODES,
-} from './ObjectOutlining.js';
-import { ensureThreeJs, initStlDesigner } from './STLLogic.js';
-import { initTestRunner } from './TestRunner.js';
+import { detectObjectContour, extractPoints } from './ObjectDetection.js';
 
-const DOM_IDS = {
-  input: 'file-upload',
-  preview: 'preview',
-};
+// Letter paper dimensions in millimetres (8.5" × 11")
+const PAPER_WIDTH_MM = 215.9;
+const PAPER_HEIGHT_MM = 279.4;
 
-const TEST_IMAGES = Object.freeze([
-  {
-    id: 'test-image-mouse',
-    label: 'Mouse on paper',
-    src: 'frontend/test-images/mouse.png.jpeg',
-  },
-  {
-    id: 'test-image-remote',
-    label: 'Remote on paper',
-    src: 'frontend/test-images/remote.png.jpeg',
-  },
-  {
-    id: 'test-image-coaster',
-    label: 'Coaster top on paper',
-    src: 'frontend/test-images/coaster-top.png.jpeg',
-  },
-]);
+// Downscale images larger than this to keep processing fast
+const MAX_DIMENSION = 1280;
 
-const TEST_IMAGE_LOOKUP = new Map(TEST_IMAGES.map((image) => [image.id, image]));
-const DEFAULT_PREVIEW_FALLBACK = 'example_coaster.jpeg';
-const DEFAULT_IMAGE_PATH = TEST_IMAGES[0]?.src ?? DEFAULT_PREVIEW_FALLBACK;
-const TEST_IMAGE_PICKER_ID = 'test-image-picker';
-const TEST_IMAGE_BUTTON_ACTIVE_CLASS = 'test-image-button--active';
+const COLOR_THEME_KEY = 'gridfinium:color-theme';
 
-const TAB_DATA_ATTRIBUTE = 'data-tab-target';
-const COLOR_THEME_STORAGE_KEY = 'gridfinium:color-theme';
-const COLOR_THEMES = Object.freeze({
-  LIGHT: 'light',
-  DARK: 'dark',
-});
+const SAMPLES = [
+  { id: 'mouse',   label: 'Mouse',   src: 'frontend/test-images/mouse.png.jpeg' },
+  { id: 'remote',  label: 'Remote',  src: 'frontend/test-images/remote.png.jpeg' },
+  { id: 'coaster', label: 'Coaster', src: 'frontend/test-images/coaster-top.png.jpeg' },
+];
 
-const HINT_TUNING_INPUT_IDS = Object.freeze({
-  low: 'hint-threshold-low',
-  high: 'hint-threshold-high',
-  kernel: 'hint-kernel-size',
-  minArea: 'hint-min-area',
-  paperTolerance: 'hint-paper-tolerance',
-  showSteps: 'hint-show-steps',
-  enableErode: 'hint-enable-erode',
-  fusionMode: 'hint-fusion-mode',
-});
-
-const POLL_INTERVAL_MS = 50;
-const MAX_DISPLAY_DIMENSION = 1280;
-
-const stlDesignerOptions = {
-  viewerId: 'stl-viewer',
-  widthInputId: 'stl-width',
-  depthInputId: 'stl-depth',
-  heightInputId: 'stl-height',
-  summaryId: 'stl-summary',
-  downloadButtonId: 'stl-download',
-  resetButtonId: 'stl-reset',
-};
-
-let fileInput = null;
-let previewContainer = null;
 let cvReady = null;
-let activePreviewToken = 0;
-let activePaperProcessingSteps = null;
-let activeHintProcessingSteps = null;
-let testImageButtons = [];
-let activeTestImageId = null;
-let defaultPreviewLoaded = false;
-
-const overlayControllers = new WeakMap();
-let processingStepsIdCounter = 0;
 
 boot();
 
-function boot() {
-  fileInput = document.getElementById(DOM_IDS.input);
-  previewContainer = document.getElementById(DOM_IDS.preview);
-  cvReady = waitForOpenCv();
-  activePreviewToken = 0;
-  setActiveImageMat(null);
-  activePaperProcessingSteps = null;
-  activeHintProcessingSteps = null;
-  testImageButtons = [];
-  activeTestImageId = null;
-  defaultPreviewLoaded = false;
-  processingStepsIdCounter = 0;
-
-  if (fileInput && previewContainer) {
-    fileInput.removeEventListener('change', handleFileSelection);
-    fileInput.addEventListener('change', handleFileSelection);
-    defaultPreviewLoaded = setupTestImagePicker();
-  } else {
-    console.warn('GridFinium: required DOM elements not found.');
-  }
-
-  if (!defaultPreviewLoaded) {
-    loadDefaultPreview(DEFAULT_IMAGE_PATH);
-  }
-
-  setupTabs();
-  setupHintTuningControls();
+async function boot() {
   setupThemeToggle();
-  initTestRunner();
+  setupSampleButtons();
+  setupFileUpload();
 
-  ensureThreeJs().finally(() => {
-    initStlDesigner(stlDesignerOptions);
-  });
-}
-
-function setupThemeToggle() {
-  const themeToggleButton = document.getElementById('theme-toggle');
-  if (!themeToggleButton) return;
-
-  const rootElement = document.documentElement;
-  const systemPreferenceQuery = window.matchMedia?.('(prefers-color-scheme: dark)') ?? null;
-
-  const applyTheme = (theme) => {
-    const normalizedTheme = theme === COLOR_THEMES.DARK ? COLOR_THEMES.DARK : COLOR_THEMES.LIGHT;
-    const isDark = normalizedTheme === COLOR_THEMES.DARK;
-    rootElement.setAttribute('data-theme', normalizedTheme);
-    themeToggleButton.setAttribute('aria-pressed', String(isDark));
-    themeToggleButton.setAttribute('aria-label', isDark ? 'Switch to light mode' : 'Switch to dark mode');
-    themeToggleButton.classList.toggle('theme-toggle--dark', isDark);
-  };
-
-  const storedTheme = localStorage.getItem(COLOR_THEME_STORAGE_KEY);
-  const hasStoredTheme = storedTheme === COLOR_THEMES.LIGHT || storedTheme === COLOR_THEMES.DARK;
-  const systemPrefersDark = systemPreferenceQuery?.matches ?? false;
-  let activeTheme = hasStoredTheme ? storedTheme : systemPrefersDark ? COLOR_THEMES.DARK : COLOR_THEMES.LIGHT;
-  let respectSystemPreference = !hasStoredTheme;
-
-  applyTheme(activeTheme);
-
-  if (respectSystemPreference && systemPreferenceQuery) {
-    const handleSystemThemeChange = (event) => {
-      if (!respectSystemPreference) return;
-      activeTheme = event.matches ? COLOR_THEMES.DARK : COLOR_THEMES.LIGHT;
-      applyTheme(activeTheme);
-    };
-
-    if (typeof systemPreferenceQuery.addEventListener === 'function') {
-      systemPreferenceQuery.addEventListener('change', handleSystemThemeChange);
-    } else if (typeof systemPreferenceQuery.addListener === 'function') {
-      systemPreferenceQuery.addListener(handleSystemThemeChange);
-    }
-  }
-
-  themeToggleButton.addEventListener('click', () => {
-    respectSystemPreference = false;
-    activeTheme = activeTheme === COLOR_THEMES.DARK ? COLOR_THEMES.LIGHT : COLOR_THEMES.DARK;
-    applyTheme(activeTheme);
-
-    try {
-      localStorage.setItem(COLOR_THEME_STORAGE_KEY, activeTheme);
-    } catch (storageError) {
-      console.warn('GridFinium: unable to store theme preference.', storageError);
-    }
-  });
-}
-
-async function handleFileSelection(event) {
-  const file = event.target?.files?.[0];
-  if (!file) return;
-
-  setActiveTestImage(null);
-
-  const objectUrl = URL.createObjectURL(file);
-
-  try {
-    await processImageFromSource(objectUrl);
-  } finally {
-    URL.revokeObjectURL(objectUrl);
-  }
-}
-
-async function processImageFromSource(imageSrc) {
-  if (!previewContainer) return;
-
-  const sessionId = ++activePreviewToken;
-
-  previewContainer.replaceChildren();
-  activePaperProcessingSteps = null;
-  activeHintProcessingSteps = null;
-  setHintProcessingStepsRenderer(null);
-
-  const {
-    heading: resultHeading,
-    canvas: resultCanvas,
-    overlay: resultOverlay,
-  } = createPreviewResultSection(previewContainer);
-
-  const imageElement = new Image();
-  const paperSteps = createStepRenderer(previewContainer, {
-    titleText: 'Paper Processing Steps',
-    startExpanded: false,
-  });
-  activePaperProcessingSteps = paperSteps;
-  activeHintProcessingSteps = createStepRenderer(previewContainer, {
-    titleText: 'Hint Processing Steps',
-    hideWhenEmpty: true,
-    startExpanded: true,
-  });
-  setHintProcessingStepsRenderer(activeHintProcessingSteps);
-  syncProcessingStepsVisibility();
-  const renderStep = (label, mat, modifier, renderOptions) => {
-    if (sessionId !== activePreviewToken) return;
-    if (modifier === 'step-outlined') {
-      resultHeading.textContent = label;
-      renderMatOnCanvas(mat, resultCanvas, renderOptions);
-      if (sessionId !== activePreviewToken) return;
-    }
-    paperSteps.renderStep(label, mat, modifier);
-  };
-
-  await loadImage(imageElement, imageSrc);
-  if (sessionId !== activePreviewToken) return;
-
+  setStatus('Loading OpenCV…', '');
+  cvReady = waitForOpenCv();
   await cvReady;
-  if (sessionId !== activePreviewToken) return;
 
-  const src = cv.imread(imageElement);
-  if (sessionId !== activePreviewToken) {
-    src.delete();
+  // Auto-process the first sample so the page is immediately useful
+  await processUrl(SAMPLES[0].src, SAMPLES[0].id);
+}
+
+// ---------------------------------------------------------------------------
+// Event wiring
+// ---------------------------------------------------------------------------
+
+function setupSampleButtons() {
+  document.querySelectorAll('[data-image-src]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      processUrl(btn.dataset.imageSrc, btn.dataset.imageId);
+    });
+  });
+}
+
+function setupFileUpload() {
+  const input = document.getElementById('file-upload');
+  if (!input) return;
+  input.addEventListener('change', async (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setActiveSample(null);
+    const url = URL.createObjectURL(file);
+    try {
+      await processUrl(url, null);
+    } finally {
+      URL.revokeObjectURL(url);
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Main processing pipeline
+// ---------------------------------------------------------------------------
+
+async function processUrl(src, sampleId) {
+  setActiveSample(sampleId);
+  setStatus('Loading image…', 'processing');
+
+  let img;
+  try {
+    img = await loadImage(src);
+  } catch {
+    setStatus('Could not load image.', 'error');
     return;
   }
 
-  setActiveImageMat(src);
+  // Compute display dimensions (cap at MAX_DIMENSION)
+  let w = img.naturalWidth;
+  let h = img.naturalHeight;
+  if (w > MAX_DIMENSION || h > MAX_DIMENSION) {
+    const scale = MAX_DIMENSION / Math.max(w, h);
+    w = Math.round(w * scale);
+    h = Math.round(h * scale);
+  }
+
+  // Draw to an offscreen canvas so OpenCV can read the pixel data
+  const offscreen = document.createElement('canvas');
+  offscreen.width = w;
+  offscreen.height = h;
+  offscreen.getContext('2d').drawImage(img, 0, 0, w, h);
+
+  setStatus('Detecting paper and object…', 'processing');
+  await cvReady;
+
+  const srcMat = cv.imread(offscreen);
+  let paperPoints = null;
+  let objectPoints = null;
+
   try {
-    renderStep('Original Photo', src, 'step-original');
-
-    const paperContour = detectPaperContour(src, renderStep);
-
-    let finalDisplay = src;
-    let finalOptions;
-
+    // Paper detection (noop for showStep since we don't display processing steps)
+    const paperContour = detectPaperContour(srcMat, () => {});
     if (paperContour) {
-      const corners = extractContourPoints(paperContour);
-      finalDisplay = src.clone();
-      const outline = new cv.MatVector();
-      outline.push_back(paperContour);
-      cv.drawContours(finalDisplay, outline, 0, new cv.Scalar(0, 255, 0, 255), 6, cv.LINE_AA);
-      outline.delete();
-      finalOptions = {
-        onRender: (info) => {
-          const controller = attachPaperOverlay(resultOverlay, corners, info);
-          overlayControllers.set(resultOverlay, controller);
-        },
-      };
+      paperPoints = extractContourPoints(paperContour);
+
+      const objContour = detectObjectContour(srcMat, paperContour);
+      if (objContour) {
+        objectPoints = extractPoints(objContour);
+        objContour.delete();
+      }
       paperContour.delete();
-    } else {
-      finalOptions = {
-        onRender: (info) => {
-          const controller = attachPaperOverlay(resultOverlay, null, info);
-          overlayControllers.set(resultOverlay, controller);
-        },
-      };
-    }
-
-    renderStep('Outlined Paper', finalDisplay, 'step-outlined', finalOptions);
-
-    if (finalDisplay !== src) {
-      finalDisplay.delete();
     }
   } finally {
-    src.delete();
+    srcMat.delete();
+  }
+
+  // Render image + overlays onto the visible canvas
+  const canvas = document.getElementById('output-canvas');
+  canvas.width = w;
+  canvas.height = h;
+  drawOverlays(canvas, img, w, h, paperPoints, objectPoints);
+  canvas.style.display = 'block';
+
+  updateResults(paperPoints, objectPoints);
+}
+
+// ---------------------------------------------------------------------------
+// Canvas drawing
+// ---------------------------------------------------------------------------
+
+function drawOverlays(canvas, img, w, h, paperPoints, objectPoints) {
+  const ctx = canvas.getContext('2d');
+
+  // Original image
+  ctx.drawImage(img, 0, 0, w, h);
+
+  const lw = Math.max(2, w / 500);
+
+  // Paper outline — semi-transparent blue fill + solid border
+  if (paperPoints?.length >= 3) {
+    ctx.beginPath();
+    ctx.moveTo(paperPoints[0].x, paperPoints[0].y);
+    for (let i = 1; i < paperPoints.length; i++) {
+      ctx.lineTo(paperPoints[i].x, paperPoints[i].y);
+    }
+    ctx.closePath();
+    ctx.fillStyle = 'rgba(59,130,246,0.10)';
+    ctx.fill();
+    ctx.strokeStyle = '#3b82f6';
+    ctx.lineWidth = lw;
+    ctx.lineJoin = 'round';
+    ctx.stroke();
+  }
+
+  // Object contour — red outline
+  if (objectPoints?.length >= 3) {
+    ctx.beginPath();
+    ctx.moveTo(objectPoints[0].x, objectPoints[0].y);
+    for (let i = 1; i < objectPoints.length; i++) {
+      ctx.lineTo(objectPoints[i].x, objectPoints[i].y);
+    }
+    ctx.closePath();
+    ctx.strokeStyle = '#ef4444';
+    ctx.lineWidth = lw;
+    ctx.lineJoin = 'round';
+    ctx.stroke();
   }
 }
 
-function setupTestImagePicker() {
-  const picker = document.getElementById(TEST_IMAGE_PICKER_ID);
-  if (!picker) return false;
+// ---------------------------------------------------------------------------
+// Dimension calculation
+// ---------------------------------------------------------------------------
 
-  const buttons = Array.from(picker.querySelectorAll('[data-test-image-id]'));
-  if (buttons.length === 0) return false;
-
-  testImageButtons = buttons;
-
-  buttons.forEach((button) => {
-    const imageId = button.getAttribute('data-test-image-id');
-    const testImage = TEST_IMAGE_LOOKUP.get(imageId);
-
-    button.type = 'button';
-    button.setAttribute('aria-pressed', 'false');
-
-    if (!testImage) {
-      button.disabled = true;
-      button.setAttribute('aria-disabled', 'true');
-      return;
-    }
-
-    button.addEventListener('click', () => {
-      if (activeTestImageId === imageId) return;
-
-      setActiveTestImage(imageId);
-      if (fileInput) {
-        fileInput.value = '';
-      }
-      loadDefaultPreview(testImage.src);
-    });
-  });
-
-  const defaultImage = TEST_IMAGES[0];
-  if (defaultImage) {
-    setActiveTestImage(defaultImage.id);
-    loadDefaultPreview(defaultImage.src);
-    return true;
-  }
-
-  return false;
+// Sort 4 corner points into [TL, TR, BR, BL] order
+function sortCorners(pts) {
+  const byY = [...pts].sort((a, b) => a.y - b.y);
+  const top = byY.slice(0, 2).sort((a, b) => a.x - b.x);
+  const bot = byY.slice(2).sort((a, b) => a.x - b.x);
+  return [top[0], top[1], bot[1], bot[0]]; // TL, TR, BR, BL
 }
 
-function setActiveTestImage(testImageId) {
-  activeTestImageId = testImageId;
-
-  if (!testImageButtons.length) return;
-
-  testImageButtons.forEach((button) => {
-    const isActive = button.getAttribute('data-test-image-id') === testImageId;
-    button.classList.toggle(TEST_IMAGE_BUTTON_ACTIVE_CLASS, isActive);
-    button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
-  });
+function dist(a, b) {
+  return Math.sqrt((a.x - b.x) ** 2 + (a.y - b.y) ** 2);
 }
 
-function createPreviewResultSection(container) {
-  ensureProcessingStyles();
+function updateResults(paperPoints, objectPoints) {
+  const container = document.getElementById('results');
+  if (!container) return;
 
-  const section = document.createElement('section');
-  section.className = 'preview-result';
-
-  const heading = document.createElement('h3');
-  heading.className = 'preview-result__heading';
-  heading.textContent = 'Detected Outline';
-
-  const canvasWrapper = document.createElement('div');
-  canvasWrapper.className = 'preview-result__canvas-wrapper';
-
-  const canvas = document.createElement('canvas');
-  canvas.className = 'preview-result__canvas';
-
-  const overlay = document.createElement('div');
-  overlay.className = 'preview-result__overlay';
-  overlay.tabIndex = 0;
-  overlay.setAttribute('role', 'application');
-  overlay.setAttribute(
-    'aria-label',
-    'Image overlay: use the click mode toggle to choose between adding hints or drawing exclusion zones. Right-click or Ctrl/Cmd-click also draws exclusions. Double-click to finish a zone; press Escape to cancel drawing.',
-  );
-  overlay.setAttribute(
-    'title',
-    'Use the click mode toggle to decide whether left-click adds hints or draws exclusion zones. Right-click or Ctrl/Cmd-click also draws exclusions. Double-click to close a zone. Press Escape to cancel drawing.',
-  );
-  overlay.addEventListener('contextmenu', (event) => {
-    event.preventDefault();
-  });
-
-  canvasWrapper.appendChild(canvas);
-  canvasWrapper.appendChild(overlay);
-  section.appendChild(heading);
-  section.appendChild(canvasWrapper);
-
-  const controls = document.createElement('div');
-  controls.className = 'preview-result__controls';
-
-  const modeToggle = document.createElement('div');
-  modeToggle.className = 'preview-result__mode-toggle';
-  modeToggle.setAttribute('role', 'group');
-  modeToggle.setAttribute('aria-label', 'Click mode');
-
-  const modeLabel = document.createElement('span');
-  modeLabel.className = 'preview-result__mode-label';
-  modeLabel.textContent = 'Click adds:';
-  modeToggle.appendChild(modeLabel);
-
-  const hintModeButton = document.createElement('button');
-  hintModeButton.type = 'button';
-  hintModeButton.className = 'preview-result__mode-button';
-  hintModeButton.textContent = 'Hints';
-  hintModeButton.setAttribute('aria-pressed', 'true');
-  hintModeButton.disabled = true;
-
-  const exclusionModeButton = document.createElement('button');
-  exclusionModeButton.type = 'button';
-  exclusionModeButton.className = 'preview-result__mode-button';
-  exclusionModeButton.textContent = 'Exclusions';
-  exclusionModeButton.setAttribute('aria-pressed', 'false');
-  exclusionModeButton.disabled = true;
-
-  modeToggle.appendChild(hintModeButton);
-  modeToggle.appendChild(exclusionModeButton);
-
-  const resetHintsButton = document.createElement('button');
-  resetHintsButton.type = 'button';
-  resetHintsButton.className = 'preview-result__button';
-  resetHintsButton.textContent = 'Reset hints';
-  resetHintsButton.disabled = true;
-  resetHintsButton.addEventListener('click', () => {
-    const controller = overlayControllers.get(overlay);
-    controller?.resetHints();
-  });
-  resetHintsButton.setAttribute('aria-label', 'Remove all hint points');
-  resetHintsButton.setAttribute('title', 'Remove all hint points');
-
-  const resetExclusionsButton = document.createElement('button');
-  resetExclusionsButton.type = 'button';
-  resetExclusionsButton.className = 'preview-result__button';
-  resetExclusionsButton.textContent = 'Reset exclusions';
-  resetExclusionsButton.disabled = true;
-  resetExclusionsButton.addEventListener('click', () => {
-    const controller = overlayControllers.get(overlay);
-    controller?.resetExclusions();
-  });
-  resetExclusionsButton.setAttribute('aria-label', 'Remove all exclusion zones');
-  resetExclusionsButton.setAttribute('title', 'Remove all exclusion zones');
-
-  const updateModeButtons = (activeMode) => {
-    const normalized = activeMode === OVERLAY_INTERACTION_MODES.EXCLUSION
-      ? OVERLAY_INTERACTION_MODES.EXCLUSION
-      : OVERLAY_INTERACTION_MODES.HINT;
-    hintModeButton.setAttribute('aria-pressed', normalized === OVERLAY_INTERACTION_MODES.HINT ? 'true' : 'false');
-    exclusionModeButton.setAttribute('aria-pressed', normalized === OVERLAY_INTERACTION_MODES.EXCLUSION ? 'true' : 'false');
-    hintModeButton.disabled = false;
-    exclusionModeButton.disabled = false;
-  };
-
-  hintModeButton.addEventListener('click', () => {
-    const controller = overlayControllers.get(overlay);
-    const mode = controller?.setInteractionMode?.(OVERLAY_INTERACTION_MODES.HINT);
-    updateModeButtons(mode ?? OVERLAY_INTERACTION_MODES.HINT);
-  });
-
-  exclusionModeButton.addEventListener('click', () => {
-    const controller = overlayControllers.get(overlay);
-    const mode = controller?.setInteractionMode?.(OVERLAY_INTERACTION_MODES.EXCLUSION);
-    updateModeButtons(mode ?? OVERLAY_INTERACTION_MODES.EXCLUSION);
-  });
-
-  controls.appendChild(modeToggle);
-  controls.appendChild(resetHintsButton);
-  controls.appendChild(resetExclusionsButton);
-  section.appendChild(controls);
-  overlay.addEventListener('gridfinium:overlay-state', (event) => {
-    const detail = event.detail ?? {};
-    const hintCount = Number(detail.hintCount) || 0;
-    const exclusionCount = Number(detail.exclusionCount) || 0;
-    resetHintsButton.disabled = hintCount === 0;
-    resetExclusionsButton.disabled = exclusionCount === 0;
-    updateModeButtons(detail.interactionMode ?? OVERLAY_INTERACTION_MODES.HINT);
-  });
-  container.appendChild(section);
-
-  return { heading, canvas, overlay };
-}
-
-function loadDefaultPreview(imageSrc) {
-  processImageFromSource(imageSrc).catch((error) => {
-    console.error('GridFinium: failed to load default preview image.', error);
-
-    if (imageSrc === DEFAULT_PREVIEW_FALLBACK) {
-      return;
-    }
-
-    if (activeTestImageId) {
-      setActiveTestImage(null);
-    }
-
-    processImageFromSource(DEFAULT_PREVIEW_FALLBACK).catch((fallbackError) => {
-      console.error('GridFinium: failed to load fallback preview image.', fallbackError);
-    });
-  });
-}
-
-function setupTabs() {
-  const tabButtons = Array.from(document.querySelectorAll(`button[${TAB_DATA_ATTRIBUTE}]`));
-  if (!tabButtons.length) return;
-
-  const tabPanels = Array.from(document.querySelectorAll('.tab-panel'));
-
-  tabButtons.forEach((button) => {
-    const isActive = button.classList.contains('is-active');
-    button.setAttribute('aria-pressed', String(isActive));
-  });
-
-  tabPanels.forEach((panel) => {
-    const isActive = panel.classList.contains('is-active');
-    panel.setAttribute('aria-hidden', String(!isActive));
-  });
-
-  const activateTab = (targetId) => {
-    const targetPanel = tabPanels.find((panel) => panel.id === targetId);
-    if (!targetPanel) return;
-
-    tabButtons.forEach((button) => {
-      const isActive = button.getAttribute(TAB_DATA_ATTRIBUTE) === targetId;
-      button.classList.toggle('is-active', isActive);
-      button.setAttribute('aria-pressed', String(isActive));
-    });
-
-    tabPanels.forEach((panel) => {
-      const isActive = panel === targetPanel;
-      panel.classList.toggle('is-active', isActive);
-      panel.setAttribute('aria-hidden', String(!isActive));
-    });
-
-    window.requestAnimationFrame(() => {
-      window.dispatchEvent(new Event('resize'));
-    });
-  };
-
-  tabButtons.forEach((button) => {
-    button.addEventListener('click', () => {
-      const targetId = button.getAttribute(TAB_DATA_ATTRIBUTE);
-      if (targetId) activateTab(targetId);
-    });
-  });
-}
-
-function setupHintTuningControls() {
-  const tuningContent = document.getElementById('hint-tuning-content');
-  const tuningToggle = document.getElementById('hint-tuning-toggle');
-
-  const lowInput = document.getElementById(HINT_TUNING_INPUT_IDS.low);
-  const highInput = document.getElementById(HINT_TUNING_INPUT_IDS.high);
-  const kernelInput = document.getElementById(HINT_TUNING_INPUT_IDS.kernel);
-  const minAreaInput = document.getElementById(HINT_TUNING_INPUT_IDS.minArea);
-  const paperToleranceInput = document.getElementById(HINT_TUNING_INPUT_IDS.paperTolerance);
-  const showStepsInput = document.getElementById(HINT_TUNING_INPUT_IDS.showSteps);
-  const erodeInput = document.getElementById(HINT_TUNING_INPUT_IDS.enableErode);
-  const fusionModeInput = document.getElementById(HINT_TUNING_INPUT_IDS.fusionMode);
-
-  if (tuningContent && tuningToggle) {
-    let tuningExpanded = false;
-
-    const syncTuningContent = () => {
-      tuningContent.dataset.expanded = tuningExpanded ? 'true' : 'false';
-      tuningContent.setAttribute('aria-hidden', String(!tuningExpanded));
-      tuningToggle.setAttribute('aria-expanded', String(tuningExpanded));
-      tuningToggle.textContent = tuningExpanded ? 'Hide details' : 'Show details';
-      tuningContent.style.maxHeight = tuningExpanded ? `${tuningContent.scrollHeight}px` : '0px';
-    };
-
-    tuningToggle.addEventListener('click', () => {
-      tuningExpanded = !tuningExpanded;
-      syncTuningContent();
-    });
-
-    syncTuningContent();
-    requestAnimationFrame(syncTuningContent);
-  }
-
-  if (
-    !lowInput
-    || !highInput
-    || !kernelInput
-    || !minAreaInput
-    || !paperToleranceInput
-    || !showStepsInput
-    || !erodeInput
-    || !fusionModeInput
-  ) {
+  if (!paperPoints || paperPoints.length < 4) {
+    setStatus('Could not detect paper. Make sure the full sheet is visible.', 'error');
+    container.innerHTML = '';
     return;
   }
 
-  const syncInputsFromState = () => {
-    const state = getHintTuningConfig();
+  const [tl, tr, br, bl] = sortCorners(paperPoints);
+  const avgPaperW = (dist(tl, tr) + dist(bl, br)) / 2;
+  const avgPaperH = (dist(tl, bl) + dist(tr, br)) / 2;
 
-    if (lowInput.type === 'number') {
-      lowInput.value = state.cannyLowThreshold.toString();
-    }
-    if (highInput.type === 'number') {
-      highInput.value = state.cannyHighThreshold.toString();
-    }
-    if (kernelInput.type === 'number') {
-      kernelInput.value = state.kernelSize.toString();
-    }
-    if (minAreaInput.type === 'number') {
-      const normalizedValue = Math.max(0, Math.min(1, state.minAreaRatio));
-      minAreaInput.value = (normalizedValue * 100).toFixed(4);
-    }
-    if (paperToleranceInput.type === 'number') {
-      const normalizedTolerance = Math.max(0, Math.min(1, state.paperExclusionTolerance));
-      paperToleranceInput.value = (normalizedTolerance * 100).toFixed(2);
-    }
-    if (showStepsInput.type === 'checkbox') {
-      showStepsInput.checked = Boolean(state.showProcessingSteps);
-    }
-    if (erodeInput.type === 'checkbox') {
-      erodeInput.checked = Boolean(state.enableErodeStep);
-    }
-    if (fusionModeInput.tagName === 'SELECT') {
-      fusionModeInput.value = state.fusionMode;
-    }
-  };
-
-  syncInputsFromState();
-
-  const parseInteger = (value, fallback) => {
-    const parsed = Number.parseInt(value, 10);
-    return Number.isFinite(parsed) ? parsed : fallback;
-  };
-
-  const parseFloatValue = (value, fallback) => {
-    const parsed = Number.parseFloat(value);
-    return Number.isFinite(parsed) ? parsed : fallback;
-  };
-
-  lowInput.addEventListener('change', () => {
-    const state = getHintTuningConfig();
-    const low = parseInteger(lowInput.value, state.cannyLowThreshold);
-    applyHintTuningState({ cannyLowThreshold: low });
-    syncInputsFromState();
-  });
-
-  highInput.addEventListener('change', () => {
-    const state = getHintTuningConfig();
-    const high = parseInteger(highInput.value, state.cannyHighThreshold);
-    applyHintTuningState({ cannyHighThreshold: high });
-    syncInputsFromState();
-  });
-
-  kernelInput.addEventListener('change', () => {
-    const state = getHintTuningConfig();
-    const kernel = parseInteger(kernelInput.value, state.kernelSize);
-    applyHintTuningState({ kernelSize: kernel });
-    syncInputsFromState();
-  });
-
-  minAreaInput.addEventListener('change', () => {
-    const state = getHintTuningConfig();
-    const value = parseFloatValue(minAreaInput.value, state.minAreaRatio * 100) / 100;
-    applyHintTuningState({ minAreaRatio: value });
-    syncInputsFromState();
-  });
-
-  paperToleranceInput.addEventListener('change', () => {
-    const state = getHintTuningConfig();
-    const value = parseFloatValue(paperToleranceInput.value, state.paperExclusionTolerance * 100) / 100;
-    applyHintTuningState({ paperExclusionTolerance: value });
-    syncInputsFromState();
-  });
-
-  showStepsInput.addEventListener('change', () => {
-    const state = getHintTuningConfig();
-    applyHintTuningState({ showProcessingSteps: Boolean(showStepsInput.checked) });
-    syncInputsFromState();
-    syncProcessingStepsVisibility();
-  });
-
-  erodeInput.addEventListener('change', () => {
-    const state = getHintTuningConfig();
-    applyHintTuningState({ enableErodeStep: Boolean(erodeInput.checked) });
-    syncInputsFromState();
-  });
-
-  fusionModeInput.addEventListener('change', () => {
-    const state = getHintTuningConfig();
-    const fallback = state.fusionMode;
-    const nextValue = typeof fusionModeInput.value === 'string' ? fusionModeInput.value : fallback;
-    applyHintTuningState({ fusionMode: nextValue });
-    syncInputsFromState();
-  });
-
-  const resetButton = document.getElementById('hint-reset');
-  if (resetButton) {
-    resetButton.addEventListener('click', () => {
-      applyHintTuningState({ ...HINT_TUNING_DEFAULTS }, { rerunSelection: false });
-      syncInputsFromState();
-      syncProcessingStepsVisibility();
-    });
+  // Determine whether the paper is portrait or landscape
+  let mmPerPxX, mmPerPxY;
+  if (avgPaperW > avgPaperH) {
+    // Landscape: the wider pixel dimension corresponds to the 11" side
+    mmPerPxX = PAPER_HEIGHT_MM / avgPaperW;
+    mmPerPxY = PAPER_WIDTH_MM / avgPaperH;
+  } else {
+    // Portrait: the taller pixel dimension corresponds to the 11" side
+    mmPerPxX = PAPER_WIDTH_MM / avgPaperW;
+    mmPerPxY = PAPER_HEIGHT_MM / avgPaperH;
   }
+
+  if (!objectPoints || objectPoints.length < 3) {
+    setStatus('Paper detected. No object found inside the paper region.', 'error');
+    container.innerHTML = '';
+    return;
+  }
+
+  const xs = objectPoints.map((p) => p.x);
+  const ys = objectPoints.map((p) => p.y);
+  const objWpx = Math.max(...xs) - Math.min(...xs);
+  const objHpx = Math.max(...ys) - Math.min(...ys);
+  const objWmm = objWpx * mmPerPxX;
+  const objHmm = objHpx * mmPerPxY;
+
+  setStatus('Paper and object detected.', 'success');
+
+  container.innerHTML = `
+    <div class="result-row">
+      <div class="result-card">
+        <h3>Object width</h3>
+        <p>${objWmm.toFixed(1)}&thinsp;mm
+          <span class="result-unit">(${(objWmm / 25.4).toFixed(2)}&thinsp;")</span>
+        </p>
+      </div>
+      <div class="result-card">
+        <h3>Object depth</h3>
+        <p>${objHmm.toFixed(1)}&thinsp;mm
+          <span class="result-unit">(${(objHmm / 25.4).toFixed(2)}&thinsp;")</span>
+        </p>
+      </div>
+    </div>
+    <p class="result-note">
+      Measured from the contour bounding box using letter paper (8.5&Prime;&thinsp;&times;&thinsp;11&Prime;) as the scale reference.
+      Place the object flat and ensure the full sheet is in frame.
+    </p>
+  `;
 }
 
-function syncProcessingStepsVisibility() {
-  const hintConfig = getHintTuningConfig();
-  const shouldShowHintSteps = Boolean(hintConfig.showProcessingSteps);
+// ---------------------------------------------------------------------------
+// UI helpers
+// ---------------------------------------------------------------------------
 
-  if (activePaperProcessingSteps) {
-    activePaperProcessingSteps.setExpanded(false);
-    activePaperProcessingSteps.setVisible(true);
-  }
-
-  if (activeHintProcessingSteps) {
-    activeHintProcessingSteps.setExpanded(true);
-    activeHintProcessingSteps.setVisible(shouldShowHintSteps);
-  }
-}
-
-function createStepRenderer(container, options = {}) {
-  const {
-    titleText = 'Paper Processing Steps',
-    hideWhenEmpty = false,
-    startExpanded = false,
-  } = options;
-
-  const section = document.createElement('section');
-  section.className = 'processing-steps';
-  if (hideWhenEmpty) {
-    section.hidden = true;
-  }
-
-  const header = document.createElement('div');
-  header.className = 'processing-steps__header';
-
-  const title = document.createElement('h3');
-  title.className = 'processing-steps__title';
-  title.textContent = titleText;
-
-  const toggle = document.createElement('button');
-  toggle.type = 'button';
-  toggle.className = 'processing-steps__toggle';
-  toggle.textContent = 'Show details';
-
-  header.appendChild(title);
-  header.appendChild(toggle);
-  section.appendChild(header);
-
-  const list = document.createElement('div');
-  list.className = 'processing-steps__list';
-  const listId = `processing-steps-${processingStepsIdCounter += 1}`;
-  list.id = listId;
-  section.appendChild(list);
-  toggle.setAttribute('aria-controls', listId);
-
-  container.appendChild(section);
-
-  let expanded = Boolean(startExpanded);
-  let visible = true;
-
-  const updateSectionVisibility = () => {
-    if (hideWhenEmpty && list.childElementCount === 0) {
-      section.hidden = true;
-    } else {
-      section.hidden = false;
-    }
-  };
-
-  const syncListStyles = () => {
-    if (!visible) {
-      list.dataset.expanded = 'false';
-      list.setAttribute('aria-hidden', 'true');
-      list.style.maxHeight = '0px';
-      return;
-    }
-
-    list.dataset.expanded = expanded ? 'true' : 'false';
-    list.setAttribute('aria-hidden', String(!expanded));
-
-    if (expanded) {
-      list.style.maxHeight = `${list.scrollHeight}px`;
-    } else {
-      list.style.maxHeight = '0px';
-    }
-  };
-
-  const syncToggleState = () => {
-    toggle.setAttribute('aria-expanded', String(visible && expanded));
-    toggle.textContent = visible && expanded ? 'Hide details' : 'Show details';
-    syncListStyles();
-  };
-
-  toggle.addEventListener('click', () => {
-    if (!visible) return;
-    expanded = !expanded;
-    syncToggleState();
-  });
-
-  syncToggleState();
-  updateSectionVisibility();
-
-  const renderStep = (label, mat, modifier, stepOptions = {}) => {
-    const wrapper = document.createElement('figure');
-    wrapper.className = 'processing-step';
-    if (modifier) wrapper.classList.add(modifier);
-
-    const canvas = document.createElement('canvas');
-    canvas.className = 'processing-canvas';
-
-    const caption = document.createElement('figcaption');
-    caption.textContent = label;
-
-    wrapper.appendChild(canvas);
-    wrapper.appendChild(caption);
-    list.appendChild(wrapper);
-
-    renderMatOnCanvas(mat, canvas);
-
-    if (Array.isArray(stepOptions.overlayPolygon) && stepOptions.overlayPolygon.length >= 3) {
-      drawNormalizedPolygonOnCanvas(canvas, stepOptions.overlayPolygon, {
-        fillStyle: stepOptions.overlayFill,
-        strokeStyle: stepOptions.overlayStroke,
-        lineWidth: stepOptions.overlayLineWidth,
-      });
-    }
-
-    if (Array.isArray(stepOptions.overlayPoints) && stepOptions.overlayPoints.length > 0) {
-      drawNormalizedPointsOnCanvas(canvas, stepOptions.overlayPoints, stepOptions.overlayPointStyle);
-    }
-
-    updateSectionVisibility();
-    syncListStyles();
-
-    if (visible && expanded) {
-      requestAnimationFrame(syncListStyles);
-    }
-  };
-
-  return {
-    renderStep,
-    reset: () => {
-      list.replaceChildren();
-      if (!visible) {
-        list.style.display = 'none';
-      } else {
-        list.style.display = '';
-      }
-      updateSectionVisibility();
-      syncListStyles();
-    },
-    setVisible: (visible) => {
-      const nextVisible = Boolean(visible);
-      toggle.disabled = !nextVisible;
-      section.classList.toggle('processing-steps--disabled', !nextVisible);
-      if (!nextVisible) {
-        expanded = false;
-        list.style.display = 'none';
-      } else {
-        list.style.display = '';
-        requestAnimationFrame(syncListStyles);
-      }
-      visible = nextVisible;
-      syncToggleState();
-      updateSectionVisibility();
-    },
-    setExpanded: (nextExpanded) => {
-      expanded = Boolean(nextExpanded);
-      syncToggleState();
-    },
-  };
-}
-
-function renderMatOnCanvas(mat, canvas, options = {}) {
-  const { displayMat, cleanup, originalWidth, originalHeight, displayWidth, displayHeight } =
-    buildDisplayMat(mat);
-  try {
-    cv.imshow(canvas, displayMat);
-  } finally {
-    cleanup();
-  }
-
-  if (typeof options.onRender === 'function') {
-    options.onRender({
-      originalWidth,
-      originalHeight,
-      displayWidth,
-      displayHeight,
-    });
-  }
-}
-
-function drawNormalizedPolygonOnCanvas(canvas, polygon, options = {}) {
-  if (!canvas || !Array.isArray(polygon) || polygon.length < 3) return;
-
-  const context = canvas.getContext('2d');
-  if (!context) return;
-
-  const fillStyle = options.fillStyle ?? 'rgba(236, 72, 153, 0.26)';
-  const strokeStyle = options.strokeStyle ?? '#ec4899';
-  const lineWidth = Number.isFinite(options.lineWidth) ? options.lineWidth : 4;
-
-  const width = canvas.width;
-  const height = canvas.height;
-  if (!width || !height) return;
-
-  const clampUnit = (value) => Math.min(Math.max(value, 0), 1);
-
-  context.save();
-  context.beginPath();
-  polygon.forEach((point, index) => {
-    if (!point) return;
-    const x = clampUnit(point.x) * width;
-    const y = clampUnit(point.y) * height;
-    if (index === 0) {
-      context.moveTo(x, y);
-    } else {
-      context.lineTo(x, y);
-    }
-  });
-  context.closePath();
-
-  if (fillStyle) {
-    context.fillStyle = fillStyle;
-    context.fill();
-  }
-
-  if (strokeStyle && lineWidth > 0) {
-    context.lineWidth = lineWidth;
-    context.strokeStyle = strokeStyle;
-    context.stroke();
-  }
-
-  context.restore();
-}
-
-function drawNormalizedPointsOnCanvas(canvas, points, style = {}) {
-  if (!canvas || !Array.isArray(points) || points.length === 0) return;
-
-  const context = canvas.getContext('2d');
-  if (!context) return;
-
-  const width = canvas.width;
-  const height = canvas.height;
-  if (!width || !height) return;
-
-  const clampUnit = (value) => Math.min(Math.max(value, 0), 1);
-  const radius = Number.isFinite(style.radius) ? style.radius : 5;
-  const fillStyle = typeof style.fillStyle === 'string' ? style.fillStyle : '#ec4899';
-  const strokeStyle = typeof style.strokeStyle === 'string' ? style.strokeStyle : '#ffffff';
-  const lineWidth = Number.isFinite(style.lineWidth) ? style.lineWidth : 2;
-
-  context.save();
-  context.fillStyle = fillStyle;
-  context.strokeStyle = strokeStyle;
-  context.lineWidth = lineWidth;
-
-  points.forEach((point) => {
-    if (!point) return;
-    const x = clampUnit(point.x) * width;
-    const y = clampUnit(point.y) * height;
-
-    context.beginPath();
-    context.arc(x, y, radius, 0, Math.PI * 2);
-    if (fillStyle) context.fill();
-    if (strokeStyle && lineWidth > 0) context.stroke();
-  });
-
-  context.restore();
-}
-
-function buildDisplayMat(mat) {
-  const width = mat.cols;
-  const height = mat.rows;
-
-  if (width <= MAX_DISPLAY_DIMENSION && height <= MAX_DISPLAY_DIMENSION) {
-    return {
-      displayMat: mat,
-      cleanup: () => {},
-      originalWidth: width,
-      originalHeight: height,
-      displayWidth: width,
-      displayHeight: height,
-    };
-  }
-
-  const scale = MAX_DISPLAY_DIMENSION / Math.max(width, height);
-  const displayWidth = Math.round(width * scale);
-  const displayHeight = Math.round(height * scale);
-  const displayMat = new cv.Mat();
-  cv.resize(mat, displayMat, new cv.Size(displayWidth, displayHeight), 0, 0, cv.INTER_AREA);
-
-  return {
-    displayMat,
-    cleanup: () => {
-      displayMat.delete();
-    },
-    originalWidth: width,
-    originalHeight: height,
-    displayWidth,
-    displayHeight,
-  };
-}
-
-function loadImage(imageElement, src) {
-  return new Promise((resolve, reject) => {
-    const handleLoad = () => {
-      cleanup();
-      resolve();
-    };
-
-    const handleError = (error) => {
-      cleanup();
-      reject(error);
-    };
-
-    const cleanup = () => {
-      imageElement.removeEventListener('load', handleLoad);
-      imageElement.removeEventListener('error', handleError);
-    };
-
-    imageElement.addEventListener('load', handleLoad);
-    imageElement.addEventListener('error', handleError);
-    imageElement.src = src;
+function setActiveSample(id) {
+  document.querySelectorAll('[data-image-id]').forEach((btn) => {
+    btn.classList.toggle('sample-btn--active', btn.dataset.imageId === id);
   });
 }
+
+function setStatus(text, state) {
+  const el = document.getElementById('status');
+  if (!el) return;
+  el.textContent = text;
+  el.className = 'status' + (state ? ` status--${state}` : '');
+}
+
+// ---------------------------------------------------------------------------
+// OpenCV readiness
+// ---------------------------------------------------------------------------
 
 function waitForOpenCv() {
-  if (typeof cv !== 'undefined' && cv.Mat) {
-    return Promise.resolve();
-  }
-
-  if (typeof window === 'undefined') {
-    return Promise.reject(new Error('OpenCV is only available in the browser.'));
-  }
-
-  return new Promise((resolve, reject) => {
-    const interval = window.setInterval(() => {
+  return new Promise((resolve) => {
+    if (typeof cv !== 'undefined' && cv.Mat) {
+      resolve();
+      return;
+    }
+    const t = setInterval(() => {
       if (typeof cv !== 'undefined' && cv.Mat) {
-        window.clearInterval(interval);
+        clearInterval(t);
         resolve();
       }
-    }, POLL_INTERVAL_MS);
-
-    window.setTimeout(() => {
-      window.clearInterval(interval);
-      reject(new Error('OpenCV initialization timed out.'));
-    }, 10000);
+    }, 50);
   });
 }
 
-let processingStylesInjected = false;
+// ---------------------------------------------------------------------------
+// Image loader
+// ---------------------------------------------------------------------------
 
-function ensureProcessingStyles() {
-  if (processingStylesInjected) return;
+function loadImage(src) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error(`Failed to load: ${src}`));
+    img.src = src;
+  });
+}
 
-  const style = document.createElement('style');
-  style.textContent = `
-    .preview-result {
-      margin-top: 24px;
-      padding: 24px;
-      border-radius: 16px;
-      background: var(--color-surface);
-      box-shadow: var(--shadow-card);
-      display: flex;
-      flex-direction: column;
-      gap: 16px;
+// ---------------------------------------------------------------------------
+// Theme toggle
+// ---------------------------------------------------------------------------
+
+function setupThemeToggle() {
+  const btn = document.getElementById('theme-toggle');
+  if (!btn) return;
+
+  const root = document.documentElement;
+  const mq = window.matchMedia?.('(prefers-color-scheme: dark)') ?? null;
+
+  const apply = (theme) => {
+    const dark = theme === 'dark';
+    root.setAttribute('data-theme', dark ? 'dark' : 'light');
+    btn.setAttribute('aria-pressed', String(dark));
+    btn.setAttribute('aria-label', dark ? 'Switch to light mode' : 'Switch to dark mode');
+    btn.classList.toggle('theme-toggle--dark', dark);
+  };
+
+  const stored = localStorage.getItem(COLOR_THEME_KEY);
+  let theme = stored === 'dark' || stored === 'light' ? stored : (mq?.matches ? 'dark' : 'light');
+  let followSystem = !stored;
+  apply(theme);
+
+  if (followSystem && mq) {
+    const onChange = (e) => {
+      if (!followSystem) return;
+      theme = e.matches ? 'dark' : 'light';
+      apply(theme);
+    };
+    if (typeof mq.addEventListener === 'function') {
+      mq.addEventListener('change', onChange);
+    } else {
+      mq.addListener?.(onChange);
     }
-    .preview-result__heading {
-      margin: 0;
-      font-size: clamp(1.5rem, 3vw, 1.8rem);
-      font-weight: 700;
-      color: var(--color-subtle-text);
-    }
-    .preview-result__canvas-wrapper {
-      position: relative;
-      width: 100%;
-      border-radius: 12px;
-      overflow: hidden;
-      background: linear-gradient(135deg, var(--color-viewer-bg-start), var(--color-viewer-bg-end));
-      box-shadow: var(--shadow-card);
-    }
-    .preview-result__canvas {
-      width: 100%;
-      height: auto;
-      display: block;
-    }
-    .preview-result__overlay {
-      position: absolute;
-      inset: 0;
-      outline: none;
-    }
-    .preview-result__svg {
-      position: absolute;
-      inset: 0;
-      width: 100%;
-      height: 100%;
-      pointer-events: none;
-    }
-    .preview-result__outline {
-      fill: rgba(34, 197, 94, 0.12);
-      stroke: #22c55e;
-      stroke-width: 6;
-      stroke-linejoin: round;
-      pointer-events: none;
-    }
-    .preview-result__exclusions {
-      pointer-events: none;
-    }
-    .preview-result__exclusion {
-      fill: rgba(239, 68, 68, 0.16);
-      stroke: rgba(239, 68, 68, 0.85);
-      stroke-width: 5;
-      stroke-linejoin: round;
-    }
-    .preview-result__exclusion--active {
-      fill: rgba(239, 68, 68, 0.1);
-      stroke-dasharray: 12 8;
-    }
-    .preview-result__exclusion[data-visible="false"],
-    .preview-result__selection[data-visible="false"] {
-      display: none;
-    }
-    .preview-result__selection {
-      fill: rgba(99, 102, 241, 0.18);
-      stroke: rgba(79, 70, 229, 0.85);
-      stroke-width: 4;
-      stroke-linejoin: round;
-    }
-    .preview-result__hint-layer {
-      position: absolute;
-      inset: 0;
-      pointer-events: none;
-    }
-    .preview-result__hint-point {
-      position: absolute;
-      width: 12px;
-      height: 12px;
-      border-radius: 50%;
-      background: #38bdf8;
-      border: 2px solid #0ea5e9;
-      box-shadow: 0 4px 8px rgba(14, 165, 233, 0.35);
-      transform: translate(-50%, -50%);
-    }
-    .preview-result__controls {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 12px;
-    }
-    .preview-result__mode-toggle {
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      padding: 6px 10px;
-      border-radius: 999px;
-      background: var(--color-surface-subtle);
-      border: 1px solid var(--color-border-soft);
-    }
-    .preview-result__mode-label {
-      font-size: 0.85rem;
-      font-weight: 600;
-      color: var(--color-muted-text);
-    }
-    .preview-result__mode-button {
-      border: none;
-      background: transparent;
-      color: var(--color-muted-text);
-      padding: 6px 14px;
-      border-radius: 999px;
-      cursor: pointer;
-      font-weight: 600;
-      transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease;
-    }
-    .preview-result__mode-button[aria-pressed="true"] {
-      background: var(--color-accent);
-      color: var(--color-accent-contrast);
-      box-shadow: var(--shadow-button-primary);
-      transform: translateY(-1px);
-    }
-    .preview-result__mode-button:disabled {
-      opacity: 0.55;
-      cursor: not-allowed;
-      transform: none;
-      box-shadow: none;
-    }
-    .preview-result__mode-button:not(:disabled):hover,
-    .preview-result__mode-button:not(:disabled):focus-visible {
-      background: var(--color-accent-hover);
-      color: var(--color-accent-contrast);
-      outline: none;
-      box-shadow: var(--shadow-button-primary-hover);
-      transform: translateY(-1px);
-    }
-    .preview-result__button {
-      border: none;
-      background: var(--color-accent);
-      color: var(--color-accent-contrast);
-      padding: 10px 20px;
-      border-radius: 999px;
-      cursor: pointer;
-      font-weight: 600;
-      transition: background 0.2s ease, transform 0.15s ease, box-shadow 0.2s ease;
-      box-shadow: var(--shadow-button-primary);
-    }
-    .preview-result__button:hover {
-      background: var(--color-accent-hover);
-      transform: translateY(-1px);
-      box-shadow: var(--shadow-button-primary-hover);
-    }
-    .preview-result__button:disabled {
-      opacity: 0.6;
-      cursor: not-allowed;
-      transform: none;
-    }
-    .preview-result__handle {
-      position: absolute;
-      width: 18px;
-      height: 18px;
-      border-radius: 50%;
-      border: 2px solid #312e81;
-      background: #ffffff;
-      box-shadow: 0 4px 10px rgba(15, 23, 42, 0.18);
-      transform: translate(-50%, -50%);
-      pointer-events: auto;
-      cursor: grab;
-      touch-action: none;
-      padding: 0;
-      transition: transform 0.15s ease, box-shadow 0.2s ease;
-    }
-    .preview-result__handle:active {
-      cursor: grabbing;
-      transform: translate(-50%, -50%) scale(1.05);
-      box-shadow: 0 6px 14px rgba(15, 23, 42, 0.24);
-    }
-    .processing-steps {
-      margin-top: 16px;
-      border: 1px solid var(--color-processing-border);
-      border-radius: 12px;
-      background: var(--color-processing-surface);
-      overflow: hidden;
-      box-shadow: var(--shadow-card);
-      transition: background 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
-    }
-    .processing-steps__header {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      padding: 12px 16px;
-      background: linear-gradient(135deg, var(--color-processing-header-start), var(--color-processing-header-end));
-    }
-    .processing-steps__title {
-      margin: 0;
-      font-size: clamp(1.35rem, 2.5vw, 1.6rem);
-      font-weight: 700;
-    }
-    .processing-steps__toggle {
-      border: none;
-      background: var(--color-accent);
-      color: var(--color-accent-contrast);
-      padding: 6px 14px;
-      border-radius: 999px;
-      cursor: pointer;
-      font-weight: 600;
-      transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease;
-      box-shadow: var(--shadow-button-primary);
-    }
-    .processing-steps__toggle:hover {
-      background: var(--color-accent-hover);
-      transform: translateY(-1px);
-      box-shadow: var(--shadow-button-primary-hover);
-    }
-    .processing-steps--disabled .processing-steps__toggle {
-      opacity: 0.6;
-      cursor: not-allowed;
-      background: var(--color-processing-toggle-disabled);
-      box-shadow: none;
-      transform: none;
-    }
-    .processing-steps--disabled .processing-steps__toggle:hover {
-      background: var(--color-processing-toggle-disabled);
-      transform: none;
-    }
-    .processing-steps__list {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-      gap: 12px;
-      padding: 0 16px;
-      max-height: 0;
-      overflow: hidden;
-      transition: max-height 0.3s ease, padding 0.2s ease;
-    }
-    .processing-steps__list[data-expanded="true"] {
-      padding: 16px;
-    }
-    .processing-step {
-      display: flex;
-      flex-direction: column;
-      gap: 8px;
-      align-items: center;
-      text-align: center;
-    }
-    .processing-step--pinned {
-      grid-column: 1 / -1;
-    }
-    .processing-step figcaption {
-      margin: 0;
-      font-size: 0.85rem;
-      color: var(--color-muted-text);
-    }
-    .processing-step .processing-canvas {
-      width: 100%;
-      height: auto;
-      border: 1px solid var(--color-processing-canvas-border);
-      border-radius: 8px;
-      background: var(--color-processing-canvas-bg);
-      box-shadow: var(--shadow-card);
-      transition: border-color 0.3s ease, background 0.3s ease, box-shadow 0.3s ease;
-    }
-    .processing-step.step-original .processing-canvas { border-color: #4caf50; }
-    .processing-step.step-gray .processing-canvas { border-color: #607d8b; }
-    .processing-step.step-blurred .processing-canvas { border-color: #8e24aa; }
-    .processing-step.step-edges-raw .processing-canvas { border-color: #1e88e5; }
-    .processing-step.step-edges-dilated .processing-canvas { border-color: #fb8c00; }
-    .processing-step.step-edges-cleaned .processing-canvas { border-color: #f4511e; }
-    .processing-step.step-contour .processing-canvas { border-color: #ff7043; }
-    .processing-step.step-outlined .processing-canvas { border-color: #2e7d32; }
-    .processing-step.step-hint-selection .processing-canvas { border-color: #ec4899; }
-  `;
-  document.head.appendChild(style);
-  processingStylesInjected = true;
+  }
+
+  btn.addEventListener('click', () => {
+    followSystem = false;
+    theme = theme === 'dark' ? 'light' : 'dark';
+    apply(theme);
+    try { localStorage.setItem(COLOR_THEME_KEY, theme); } catch (_) { /* storage unavailable */ }
+  });
 }

--- a/frontend/js/ObjectDetection.js
+++ b/frontend/js/ObjectDetection.js
@@ -1,0 +1,122 @@
+/**
+ * ObjectDetection.js
+ *
+ * Detects the main object placed on a piece of letter paper.
+ *
+ * Strategy:
+ *  1. Build a mask from the paper contour and erode it inward to avoid
+ *     picking up the paper's own border as an edge.
+ *  2. Run Canny edge detection only inside the masked region.
+ *  3. Dilate edges to close small gaps.
+ *  4. Find the largest external contour that is neither too tiny nor
+ *     suspiciously close in size to the whole paper.
+ *  5. Simplify with approxPolyDP at a loose epsilon so the returned
+ *     polygon is smooth and printable-friendly.
+ */
+
+/**
+ * @param {cv.Mat} src           - RGBA source image (from cv.imread)
+ * @param {cv.Mat} paperContour  - 4-corner paper polygon from detectPaperContour
+ * @returns {cv.Mat|null}        - Caller must .delete() the returned Mat
+ */
+export function detectObjectContour(src, paperContour) {
+  if (!paperContour) return null;
+
+  const gray = new cv.Mat();
+  const masked = new cv.Mat();
+  const blurred = new cv.Mat();
+  const edges = new cv.Mat();
+  const contours = new cv.MatVector();
+  const hierarchy = new cv.Mat();
+  // Mat.zeros must be assigned after declaration because it returns a new Mat
+  const mask = cv.Mat.zeros(src.rows, src.cols, cv.CV_8U);
+
+  try {
+    // 1. Fill the paper polygon into the mask
+    const pv = new cv.MatVector();
+    pv.push_back(paperContour);
+    cv.fillPoly(mask, pv, new cv.Scalar(255));
+    pv.delete();
+
+    // 2. Erode inward to avoid the paper border triggering as an edge
+    const erodeKernel = cv.Mat.ones(15, 15, cv.CV_8U);
+    cv.erode(mask, mask, erodeKernel);
+    erodeKernel.delete();
+
+    // 3. Grayscale + apply mask (zeros outside paper)
+    cv.cvtColor(src, gray, cv.COLOR_RGBA2GRAY);
+    cv.bitwise_and(gray, mask, masked);
+
+    // 4. Blur to reduce paper texture noise
+    cv.GaussianBlur(masked, blurred, new cv.Size(7, 7), 0);
+
+    // 5. Edge detection
+    cv.Canny(blurred, edges, 20, 60);
+
+    // 6. Dilate to close small gaps in the object outline
+    const dilateKernel = cv.Mat.ones(7, 7, cv.CV_8U);
+    cv.dilate(edges, edges, dilateKernel);
+    dilateKernel.delete();
+
+    // 7. Find external contours only
+    cv.findContours(edges, contours, hierarchy, cv.RETR_EXTERNAL, cv.CHAIN_APPROX_SIMPLE);
+
+    const paperArea = cv.contourArea(paperContour);
+    // Ignore anything smaller than 0.3% of the image (noise specks)
+    const minArea = src.rows * src.cols * 0.003;
+
+    let bestContour = null;
+    let bestArea = 0;
+
+    for (let i = 0; i < contours.size(); i++) {
+      const c = contours.get(i);
+      const area = cv.contourArea(c);
+
+      // Skip too small or suspiciously close to full-paper size (the paper border)
+      if (area < minArea || area > paperArea * 0.85) {
+        c.delete();
+        continue;
+      }
+
+      if (area > bestArea) {
+        if (bestContour) bestContour.delete();
+        bestContour = c.clone();
+        bestArea = area;
+      }
+      c.delete();
+    }
+
+    if (!bestContour) return null;
+
+    // 8. Simplify to a loose polygon: 2.5% of perimeter as epsilon
+    //    Higher epsilon = fewer points = smoother, more printable shape
+    const simplified = new cv.Mat();
+    const perimeter = cv.arcLength(bestContour, true);
+    cv.approxPolyDP(bestContour, simplified, 0.025 * perimeter, true);
+    bestContour.delete();
+
+    return simplified;
+  } finally {
+    gray.delete();
+    masked.delete();
+    blurred.delete();
+    edges.delete();
+    contours.delete();
+    hierarchy.delete();
+    mask.delete();
+  }
+}
+
+/**
+ * Converts a cv.Mat contour to an array of {x, y} points.
+ * @param {cv.Mat} contour
+ * @returns {{ x: number, y: number }[]}
+ */
+export function extractPoints(contour) {
+  const data = contour.data32S;
+  const pts = [];
+  for (let i = 0; i < data.length; i += 2) {
+    pts.push({ x: data[i], y: data[i + 1] });
+  }
+  return pts;
+}

--- a/index.html
+++ b/index.html
@@ -5,15 +5,17 @@
   <script type="module" src="frontend/js/MainScript.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>GridFinium</title>
+  <title>Gridfinium</title>
   <link rel="icon" type="image/svg+xml" href="frontend/favicon.svg">
   <style>
+    /* ── Design tokens ──────────────────────────────────────────────────── */
     :root {
       color-scheme: light;
       font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       line-height: 1.5;
       background-color: var(--color-body-bg);
       color: var(--color-body-text);
+
       --color-body-bg: #f5f6fa;
       --color-body-text: #1f2933;
       --color-surface: #ffffff;
@@ -22,24 +24,10 @@
       --color-border-strong: rgba(148, 163, 184, 0.4);
       --color-subtle-text: #475569;
       --color-muted-text: #64748b;
-      --color-tab-bg: #eef2ff;
-      --color-tab-text: #475569;
-      --color-tab-hover-bg: rgba(99, 102, 241, 0.16);
-      --color-tab-hover-text: #312e81;
       --color-accent: #4f46e5;
       --color-accent-hover: #4338ca;
       --color-accent-contrast: #ffffff;
-      --color-secondary-bg: #e0e7ff;
-      --color-secondary-text: #312e81;
-      --color-card-header-start: #eef2ff;
-      --color-card-header-end: #f8fafc;
-      --color-viewer-bg-start: #f8fafc;
-      --color-viewer-bg-end: #e2e8f0;
       --color-focus-outline: rgba(99, 102, 241, 0.2);
-      --shadow-elevated: 0 14px 30px rgba(15, 23, 42, 0.12);
-      --shadow-card: 0 10px 24px rgba(15, 23, 42, 0.12);
-      --shadow-button-primary: 0 8px 16px rgba(79, 70, 229, 0.35);
-      --shadow-button-primary-hover: 0 12px 20px rgba(79, 70, 229, 0.28);
       --color-sample-border: #cbd5f5;
       --color-sample-bg-start: #f8faff;
       --color-sample-bg-end: #eef2ff;
@@ -48,13 +36,10 @@
       --color-sample-button-text: #1f2933;
       --color-sample-button-hover-bg: rgba(99, 102, 241, 0.12);
       --color-sample-button-hover-text: #312e81;
-      --color-processing-surface: var(--color-surface);
-      --color-processing-border: rgba(148, 163, 184, 0.35);
-      --color-processing-header-start: #eef2ff;
-      --color-processing-header-end: #f8fafc;
-      --color-processing-toggle-disabled: #9ca3af;
-      --color-processing-canvas-border: rgba(148, 163, 184, 0.35);
-      --color-processing-canvas-bg: #f8fafc;
+      --shadow-elevated: 0 14px 30px rgba(15, 23, 42, 0.12);
+      --shadow-card: 0 10px 24px rgba(15, 23, 42, 0.12);
+      --shadow-button-primary: 0 8px 16px rgba(79, 70, 229, 0.35);
+      --shadow-button-primary-hover: 0 12px 20px rgba(79, 70, 229, 0.28);
     }
 
     [data-theme="dark"] {
@@ -67,24 +52,10 @@
       --color-border-strong: rgba(96, 165, 250, 0.35);
       --color-subtle-text: #cbd5f5;
       --color-muted-text: #94a3b8;
-      --color-tab-bg: rgba(99, 102, 241, 0.14);
-      --color-tab-text: #cbd5f5;
-      --color-tab-hover-bg: rgba(99, 102, 241, 0.3);
-      --color-tab-hover-text: #eef2ff;
       --color-accent: #6366f1;
       --color-accent-hover: #818cf8;
       --color-accent-contrast: #e0e7ff;
-      --color-secondary-bg: rgba(99, 102, 241, 0.22);
-      --color-secondary-text: #e0e7ff;
-      --color-card-header-start: #312e81;
-      --color-card-header-end: #1e1b4b;
-      --color-viewer-bg-start: #1f2937;
-      --color-viewer-bg-end: #111827;
       --color-focus-outline: rgba(99, 102, 241, 0.35);
-      --shadow-elevated: 0 16px 40px rgba(2, 6, 23, 0.6);
-      --shadow-card: 0 18px 36px rgba(2, 6, 23, 0.55);
-      --shadow-button-primary: 0 10px 24px rgba(99, 102, 241, 0.45);
-      --shadow-button-primary-hover: 0 12px 28px rgba(129, 140, 248, 0.5);
       --color-sample-border: rgba(129, 140, 248, 0.65);
       --color-sample-bg-start: rgba(79, 70, 229, 0.22);
       --color-sample-bg-end: rgba(30, 27, 75, 0.65);
@@ -93,18 +64,14 @@
       --color-sample-button-text: #e0e7ff;
       --color-sample-button-hover-bg: rgba(99, 102, 241, 0.32);
       --color-sample-button-hover-text: #f8fafc;
-      --color-processing-surface: rgba(17, 24, 39, 0.85);
-      --color-processing-border: rgba(99, 102, 241, 0.45);
-      --color-processing-header-start: rgba(79, 70, 229, 0.35);
-      --color-processing-header-end: rgba(30, 41, 59, 0.8);
-      --color-processing-toggle-disabled: rgba(148, 163, 184, 0.45);
-      --color-processing-canvas-border: rgba(99, 102, 241, 0.45);
-      --color-processing-canvas-bg: rgba(15, 23, 42, 0.75);
+      --shadow-elevated: 0 16px 40px rgba(2, 6, 23, 0.6);
+      --shadow-card: 0 18px 36px rgba(2, 6, 23, 0.55);
+      --shadow-button-primary: 0 10px 24px rgba(99, 102, 241, 0.45);
+      --shadow-button-primary-hover: 0 12px 28px rgba(129, 140, 248, 0.5);
     }
 
-    html {
-      background-color: var(--color-body-bg);
-    }
+    /* ── Base ───────────────────────────────────────────────────────────── */
+    html { background-color: var(--color-body-bg); }
 
     body {
       margin: 0;
@@ -122,15 +89,18 @@
       border-radius: 16px;
       box-shadow: var(--shadow-elevated);
       padding: 32px clamp(20px, 4vw, 48px);
-      transition: background-color 0.3s ease, box-shadow 0.3s ease, color 0.3s ease;
+      display: flex;
+      flex-direction: column;
+      gap: 28px;
+      transition: background-color 0.3s ease, box-shadow 0.3s ease;
     }
 
+    /* ── Header ─────────────────────────────────────────────────────────── */
     .app-header {
       display: flex;
       align-items: center;
       justify-content: space-between;
       gap: 16px;
-      margin-bottom: 24px;
       flex-wrap: wrap;
     }
 
@@ -140,6 +110,14 @@
       letter-spacing: 0.04em;
     }
 
+    .app-subtitle {
+      margin: 0;
+      color: var(--color-muted-text);
+      font-size: 0.95rem;
+      max-width: 55ch;
+    }
+
+    /* ── Theme toggle ───────────────────────────────────────────────────── */
     .theme-toggle {
       --toggle-width: 120px;
       --toggle-height: 32px;
@@ -155,7 +133,7 @@
       height: var(--toggle-height);
       position: relative;
       cursor: pointer;
-      transition: background-color 0.25s ease, border-color 0.25s ease, color 0.25s ease, box-shadow 0.2s ease;
+      transition: background-color 0.25s, border-color 0.25s, color 0.25s, box-shadow 0.2s;
       font-size: 0.75rem;
       font-weight: 600;
       letter-spacing: 0.05em;
@@ -175,7 +153,7 @@
     .theme-toggle__label {
       line-height: 1;
       opacity: 0.45;
-      transition: opacity 0.2s ease, color 0.2s ease;
+      transition: opacity 0.2s, color 0.2s;
       pointer-events: none;
     }
 
@@ -188,8 +166,7 @@
       border-radius: 999px;
       background: var(--color-surface);
       box-shadow: 0 6px 12px rgba(15, 23, 42, 0.18);
-      transition: transform 0.25s ease, background-color 0.25s ease, box-shadow 0.25s ease;
-      transform: translateX(0);
+      transition: transform 0.25s, background-color 0.25s, box-shadow 0.25s;
       pointer-events: none;
     }
 
@@ -210,130 +187,35 @@
       color: var(--color-body-text);
     }
 
-    .tab-bar {
-      display: flex;
-      gap: 8px;
-      background: var(--color-tab-bg);
-      padding: 6px;
-      border-radius: 999px;
-      margin-bottom: 24px;
-      justify-content: center;
-      transition: background-color 0.3s ease;
-    }
-
-    .tab-button {
-      border: none;
-      background: transparent;
-      color: var(--color-tab-text);
-      font-weight: 600;
-      padding: 10px 22px;
-      border-radius: 999px;
-      cursor: pointer;
-      transition: background 0.2s ease, color 0.2s ease, transform 0.15s ease;
-    }
-
-    .tab-button:hover {
-      background: var(--color-tab-hover-bg);
-      color: var(--color-tab-hover-text);
-      transform: translateY(-1px);
-    }
-
-    .tab-button.is-active {
-      background: var(--color-accent);
-      color: var(--color-accent-contrast);
-      box-shadow: var(--shadow-button-primary);
-    }
-
-    .tab-panel {
-      display: none;
-    }
-
-    .tab-panel.is-active {
-      display: block;
-      animation: fade-in 180ms ease;
-    }
-
-    .hint-tuning-card {
-      margin-top: 36px;
-      border: 1px solid var(--color-border-soft);
-      border-radius: 12px;
-      background: var(--color-surface);
-      box-shadow: var(--shadow-card);
-      overflow: hidden;
-      transition: background-color 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
-    }
-
-    .hint-tuning-card__header {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      padding: 18px 20px;
-      background: linear-gradient(135deg, var(--color-card-header-start), var(--color-card-header-end));
-      gap: 12px;
-      transition: background 0.3s ease;
-    }
-
-    .hint-tuning-card__title,
-    .processing-steps__title {
-      margin: 0;
-      font-size: clamp(1.35rem, 2.5vw, 1.6rem);
-      font-weight: 700;
-    }
-
-    .hint-tuning-card__toggle {
-      border: none;
-      background: var(--color-accent);
-      color: var(--color-accent-contrast);
-      padding: 8px 18px;
-      border-radius: 999px;
-      cursor: pointer;
-      font-weight: 600;
-      transition: background 0.2s ease, transform 0.15s ease, box-shadow 0.2s ease;
-      box-shadow: var(--shadow-button-primary);
-    }
-
-    .hint-tuning-card__toggle:hover {
-      background: var(--color-accent-hover);
-      transform: translateY(-1px);
-      box-shadow: var(--shadow-button-primary-hover);
-    }
-
-    .test-image-picker {
-      margin-top: 28px;
+    /* ── Sample picker ──────────────────────────────────────────────────── */
+    .sample-picker {
       padding: 20px clamp(16px, 4vw, 24px);
       border-radius: 16px;
       border: 1px dashed var(--color-sample-border);
       background: linear-gradient(135deg, var(--color-sample-bg-start), var(--color-sample-bg-end));
       box-shadow: var(--shadow-card);
-      transition: background 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+      transition: background 0.3s, border-color 0.3s, box-shadow 0.3s;
     }
 
-    .test-image-picker__intro {
-      display: flex;
-      flex-direction: column;
-      gap: 6px;
+    .sample-picker__heading {
+      margin: 0 0 4px;
+      font-size: 1.1rem;
+      font-weight: 700;
     }
 
-    .test-image-picker__heading {
-      margin: 0;
-      font-size: clamp(1.4rem, 3vw, 1.6rem);
-    }
-
-    .test-image-picker__description {
-      margin: 0;
+    .sample-picker__description {
+      margin: 0 0 14px;
       color: var(--color-subtle-text);
-      font-size: 0.95rem;
-      max-width: 62ch;
+      font-size: 0.9rem;
     }
 
-    .test-image-picker__buttons {
+    .sample-buttons {
       display: flex;
       flex-wrap: wrap;
-      gap: 12px;
-      margin-top: 18px;
+      gap: 10px;
     }
 
-    .test-image-button {
+    .sample-btn {
       border: 1px solid var(--color-sample-button-border);
       background: var(--color-sample-button-bg);
       color: var(--color-sample-button-text);
@@ -341,696 +223,282 @@
       border-radius: 12px;
       font-weight: 600;
       cursor: pointer;
-      transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease;
+      transition: background 0.2s, color 0.2s, box-shadow 0.2s, transform 0.15s;
       box-shadow: var(--shadow-card);
     }
 
-    .test-image-button:hover {
+    .sample-btn:hover {
       background: var(--color-sample-button-hover-bg);
       color: var(--color-sample-button-hover-text);
       transform: translateY(-1px);
     }
 
-    .test-image-button:focus-visible {
+    .sample-btn:focus-visible {
       outline: 2px solid var(--color-accent);
       outline-offset: 2px;
     }
 
-    .test-image-button--active {
+    .sample-btn--active {
       background: var(--color-accent);
       color: var(--color-accent-contrast);
       border-color: var(--color-accent);
       box-shadow: var(--shadow-button-primary);
     }
 
-    .hint-tuning-card__toggle:disabled {
-      opacity: 0.6;
-      cursor: not-allowed;
-      transform: none;
-    }
-
-    .hint-tuning-card__content {
-      padding: 0 20px;
-      overflow: hidden;
-      max-height: 0;
-      transition: max-height 0.3s ease, padding 0.2s ease;
-    }
-
-    .hint-tuning-card__content[data-expanded="true"] {
-      padding: 20px;
-    }
-
-    .hint-tuning-card__description {
-      margin-top: 0;
-      margin-bottom: 18px;
-      color: var(--color-subtle-text);
-    }
-
-    .tuning-grid {
-      display: grid;
-      gap: 18px;
-      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    }
-
-    .tuning-field {
-      display: grid;
-      gap: 8px;
-    }
-
-    .tuning-field label {
-      font-weight: 600;
-    }
-
-    .tuning-field input[type="number"] {
-      border-radius: 10px;
-      border: 1px solid var(--color-border-soft);
-      padding: 10px 14px;
-      font-size: 1rem;
-      transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
-      background-color: var(--color-surface-subtle);
-      color: var(--color-body-text);
-    }
-
-    .tuning-field input[type="number"]:focus {
-      outline: none;
-      border-color: var(--color-accent);
-      box-shadow: 0 0 0 3px var(--color-focus-outline);
-    }
-
-    .tuning-note {
-      margin: 0;
-      font-size: 0.85rem;
-      color: var(--color-muted-text);
-      line-height: 1.4;
-    }
-
-    .tuning-checkbox {
-      display: flex;
-      align-items: flex-start;
+    /* ── Upload ─────────────────────────────────────────────────────────── */
+    .upload-label {
+      display: inline-flex;
+      align-items: center;
       gap: 10px;
-      margin-top: 12px;
+      border: 1px solid var(--color-border-soft);
+      background: var(--color-surface-subtle);
+      padding: 10px 20px;
+      border-radius: 12px;
+      cursor: pointer;
       font-weight: 600;
-      color: var(--color-body-text);
+      color: var(--color-subtle-text);
+      transition: border-color 0.2s, color 0.2s, background 0.2s;
+      box-shadow: var(--shadow-card);
     }
 
-    .tuning-checkbox input[type="checkbox"] {
-      margin-top: 4px;
-      accent-color: var(--color-accent);
-      width: 18px;
-      height: 18px;
+    .upload-label:hover {
+      border-color: var(--color-accent);
+      color: var(--color-accent);
+      background: var(--color-sample-button-hover-bg);
     }
 
-    @keyframes fade-in {
-      from {
-        opacity: 0;
-        transform: translateY(4px);
-      }
-
-      to {
-        opacity: 1;
-        transform: translateY(0);
-      }
+    .upload-label input[type="file"] {
+      position: absolute;
+      opacity: 0;
+      width: 0;
+      height: 0;
     }
 
-    section + section {
-      margin-top: 32px;
+    /* ── Status bar ─────────────────────────────────────────────────────── */
+    .status {
+      padding: 10px 16px;
+      border-radius: 10px;
+      background: var(--color-surface-subtle);
+      border: 1px solid var(--color-border-soft);
+      color: var(--color-subtle-text);
+      font-size: 0.9rem;
+      transition: border-color 0.2s, color 0.2s;
     }
 
-    #preview {
-      margin-top: 20px;
+    .status--processing {
+      border-color: var(--color-accent);
+      color: var(--color-accent);
     }
 
-    .stl-grid {
+    .status--success {
+      border-color: #22c55e;
+      color: #15803d;
+    }
+
+    [data-theme="dark"] .status--success {
+      color: #4ade80;
+    }
+
+    .status--error {
+      border-color: #f87171;
+      color: #dc2626;
+    }
+
+    [data-theme="dark"] .status--error {
+      color: #f87171;
+    }
+
+    /* ── Canvas ─────────────────────────────────────────────────────────── */
+    .canvas-wrapper {
+      border-radius: 12px;
+      overflow: hidden;
+      border: 1px solid var(--color-border-soft);
+      background: var(--color-surface-subtle);
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 80px;
+      transition: border-color 0.3s;
+    }
+
+    #output-canvas {
+      display: none;
+      max-width: 100%;
+      max-height: 500px;
+      width: auto;
+      height: auto;
+    }
+
+    /* ── Results ────────────────────────────────────────────────────────── */
+    .result-row {
       display: grid;
-      gap: 16px;
-      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      align-items: start;
-    }
-
-    .stl-form {
-      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
       gap: 14px;
     }
 
-    .stl-form label {
-      display: grid;
-      gap: 6px;
-      font-weight: 600;
-    }
-
-    .stl-form input[type="number"] {
-      border-radius: 10px;
-      border: 1px solid var(--color-border-soft);
-      padding: 10px 14px;
-      font-size: 1rem;
-      transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
-      background-color: var(--color-surface-subtle);
-      color: var(--color-body-text);
-    }
-
-    .stl-form input[type="number"]:focus {
-      outline: none;
-      border-color: var(--color-accent);
-      box-shadow: 0 0 0 3px var(--color-focus-outline);
-    }
-
-    .stl-actions {
-      display: flex;
-      gap: 12px;
-      flex-wrap: wrap;
-      margin-top: 8px;
-    }
-
-    .stl-button {
-      border: none;
+    .result-card {
+      padding: 16px 18px;
       border-radius: 12px;
-      padding: 10px 18px;
-      font-weight: 600;
-      cursor: pointer;
-      background: var(--color-accent);
-      color: var(--color-accent-contrast);
-      box-shadow: var(--shadow-button-primary);
-      transition: transform 0.15s ease, box-shadow 0.2s ease, background-color 0.2s ease;
-    }
-
-    .stl-button:hover {
-      transform: translateY(-1px);
-      box-shadow: var(--shadow-button-primary-hover);
-      background: var(--color-accent-hover);
-    }
-
-    .stl-button.secondary {
-      background: var(--color-secondary-bg);
-      color: var(--color-secondary-text);
-      box-shadow: none;
-    }
-
-    .stl-summary {
-      margin: 0;
-      font-size: 0.95rem;
-      color: var(--color-subtle-text);
-    }
-
-    .stl-viewer {
-      width: 100%;
-      height: clamp(260px, 40vh, 400px);
-      background: radial-gradient(circle at 30% 30%, var(--color-viewer-bg-start), var(--color-viewer-bg-end));
-      border-radius: 16px;
-      position: relative;
-      overflow: hidden;
-      border: 1px solid var(--color-border-strong);
-      transition: background 0.3s ease, border-color 0.3s ease;
-    }
-
-    .stl-viewer__canvas {
-      width: 100%;
-      height: 100%;
-      display: block;
-      cursor: grab;
-      touch-action: none;
-    }
-
-    .stl-viewer__canvas:active {
-      cursor: grabbing;
-    }
-
-    .stl-tip {
-      margin-top: 12px;
-      color: var(--color-muted-text);
-      font-size: 0.9rem;
-    }
-
-    .tests-panel {
-      display: flex;
-      flex-direction: column;
-      gap: 16px;
-    }
-
-    .tests-controls {
-      display: flex;
-      justify-content: flex-end;
-    }
-
-    .tests-run-button {
-      border: none;
-      background: var(--color-accent);
-      color: var(--color-accent-contrast);
-      padding: 10px 20px;
-      border-radius: 999px;
-      cursor: pointer;
-      font-weight: 600;
-      transition: background 0.2s ease, transform 0.15s ease, box-shadow 0.2s ease;
-      box-shadow: var(--shadow-button-primary);
-    }
-
-    .tests-run-button:hover,
-    .tests-run-button:focus-visible {
-      background: var(--color-accent-hover);
-      transform: translateY(-1px);
-      outline: none;
-      box-shadow: var(--shadow-button-primary-hover);
-    }
-
-    .tests-run-button:disabled {
-      opacity: 0.6;
-      cursor: not-allowed;
-      transform: none;
-    }
-
-    .tests-table-wrapper {
-      border-radius: 16px;
-      background: var(--color-surface);
-      box-shadow: var(--shadow-card);
-      overflow-x: auto;
-    }
-
-    .tests-table {
-      width: 100%;
-      border-collapse: collapse;
-      min-width: 640px;
-    }
-
-    .tests-table th,
-    .tests-table td {
-      text-align: left;
-      padding: 12px 16px;
-      border-bottom: 1px solid var(--color-border-soft);
-      font-size: 0.9rem;
-    }
-
-    .tests-table th {
       background: var(--color-surface-subtle);
-      color: var(--color-subtle-text);
-      font-weight: 600;
+      border: 1px solid var(--color-border-soft);
+      animation: fade-in 200ms ease;
     }
 
-    .tests-status {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      gap: 4px;
-      font-weight: 700;
+    .result-card h3 {
+      margin: 0 0 6px;
+      font-size: 0.8rem;
       text-transform: uppercase;
-      letter-spacing: 0.04em;
-      font-size: 0.75rem;
-      padding: 4px 10px;
-      border-radius: 999px;
-      border: 1px solid transparent;
-    }
-
-    .tests-status--pass {
-      color: #16a34a;
-      background: rgba(22, 163, 74, 0.12);
-      border-color: rgba(22, 163, 74, 0.32);
-    }
-
-    .tests-status--fail {
-      color: #dc2626;
-      background: rgba(220, 38, 38, 0.12);
-      border-color: rgba(220, 38, 38, 0.32);
-    }
-
-    .tests-details {
-      padding: 12px 16px;
-      background: var(--color-surface-subtle);
-      border-radius: 12px;
-      border: 1px solid var(--color-border-soft);
-    }
-
-    .tests-details summary {
-      cursor: pointer;
+      letter-spacing: 0.07em;
+      color: var(--color-muted-text);
       font-weight: 600;
-      color: var(--color-subtle-text);
     }
 
-    .tests-details__meta {
-      display: grid;
-      gap: 4px;
-      margin-top: 10px;
+    .result-card p {
+      margin: 0;
+      font-size: 1.3rem;
+      font-weight: 700;
+    }
+
+    .result-unit {
+      font-size: 0.9rem;
+      font-weight: 500;
+      color: var(--color-muted-text);
+    }
+
+    .result-note {
+      margin: 0;
       font-size: 0.85rem;
       color: var(--color-muted-text);
+      line-height: 1.5;
     }
 
-    .tests-details__list {
-      list-style: none;
-      padding: 0;
-      margin: 12px 0 0;
-      display: grid;
-      gap: 12px;
-    }
-
-    .tests-details__title {
-      font-weight: 600;
-      margin-bottom: 4px;
-    }
-
-    .tests-details__message {
-      color: var(--color-muted-text);
-      font-size: 0.85rem;
-    }
-
-    .tests-details__metrics {
-      margin: 8px 0 0;
-      padding: 8px 12px;
-      background: var(--color-surface);
-      border-radius: 8px;
-      font-size: 0.75rem;
-      color: var(--color-subtle-text);
-      border: 1px solid var(--color-border-soft);
-    }
-
-    .tests-table__empty {
-      color: var(--color-muted-text);
-      text-align: center;
-      padding: 24px;
-    }
-
-    .tests-table__empty--error {
-      color: #dc2626;
-    }
-
-    .tests-cards {
-      display: none;
-      flex-direction: column;
-      gap: 16px;
-    }
-
-    .tests-card {
-      background: var(--color-surface);
-      border-radius: 16px;
-      box-shadow: var(--shadow-card);
-      padding: 16px;
-      border: 1px solid var(--color-border-soft);
+    /* ── Overlay legend ─────────────────────────────────────────────────── */
+    .legend {
       display: flex;
-      flex-direction: column;
-      gap: 12px;
+      gap: 20px;
+      flex-wrap: wrap;
+      font-size: 0.85rem;
+      color: var(--color-subtle-text);
     }
 
-    .tests-card__header {
+    .legend-item {
       display: flex;
       align-items: center;
-      justify-content: space-between;
-      gap: 12px;
-      flex-wrap: wrap;
+      gap: 7px;
     }
 
-    .tests-card__title {
-      margin: 0;
-      font-size: 1.05rem;
-      word-break: break-word;
+    .legend-swatch {
+      width: 28px;
+      height: 4px;
+      border-radius: 2px;
+      flex-shrink: 0;
     }
 
-    .tests-card__overall {
-      font-size: 0.78rem;
+    /* ── Animations ─────────────────────────────────────────────────────── */
+    @keyframes fade-in {
+      from { opacity: 0; transform: translateY(4px); }
+      to   { opacity: 1; transform: translateY(0); }
     }
 
-    .tests-card__list {
-      list-style: none;
-      margin: 0;
-      padding: 0;
-      display: grid;
-      gap: 10px;
-    }
-
-    .tests-card__row {
-      display: grid;
-      gap: 6px;
-    }
-
-    .tests-card__stage {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 12px;
-      flex-wrap: wrap;
-      font-weight: 600;
-      color: var(--color-subtle-text);
-    }
-
-    .tests-card__details {
-      background: var(--color-surface-subtle);
-      border-radius: 12px;
-      border: 1px solid var(--color-border-soft);
-      padding: 10px 12px;
-    }
-
-    .tests-card__details summary {
-      cursor: pointer;
-      font-weight: 600;
-      color: var(--color-subtle-text);
-    }
-
-    .tests-card__details-body {
-      margin-top: 8px;
-      font-size: 0.85rem;
-      color: var(--color-muted-text);
-      display: grid;
-      gap: 6px;
-    }
-
-    .tests-card__empty {
-      text-align: center;
-      color: var(--color-muted-text);
-    }
-
-    .tests-table td.tests-sample {
-      max-width: 220px;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-
-    .tests-sandbox {
-      position: absolute;
-      left: -9999px;
-      top: -9999px;
-      width: 1px;
-      height: 1px;
-      overflow: hidden;
-    }
-
+    /* ── Responsive ─────────────────────────────────────────────────────── */
     @media (max-width: 640px) {
-      body {
-        padding: 16px;
-      }
-
-      main.app {
-        padding: 24px 18px;
-      }
-
-      .app-header {
-        flex-direction: column;
-        align-items: stretch;
-        gap: 12px;
-      }
-
-      .app-title {
-        text-align: center;
-      }
-
-      .theme-toggle {
-        align-self: center;
-      }
-
-      .stl-actions {
-        flex-direction: column;
-      }
-
-      .stl-button {
-        width: 100%;
-        text-align: center;
-      }
-    }
-
-    @media (max-width: 480px) {
-      .tests-panel {
-        gap: 12px;
-        padding-bottom: calc(96px + env(safe-area-inset-bottom));
-      }
-
-      .tests-panel h2 {
-        margin: 0 0 6px;
-        font-size: 1.4rem;
-      }
-
-      .tests-controls {
-        position: sticky;
-        bottom: 0;
-        z-index: 10;
-        padding: 8px 0 calc(12px + env(safe-area-inset-bottom));
-        background: var(--color-surface);
-      }
-
-      .tests-run-button {
-        width: 100%;
-        padding: 14px 20px;
-        min-height: 44px;
-        font-size: 1rem;
-      }
-
-      .tests-table-wrapper {
-        display: none;
-      }
-
-      .tests-cards {
-        display: flex;
-      }
-
-      .tests-status {
-        font-size: 0.85rem;
-        padding: 6px 12px;
-      }
+      body { padding: 16px; }
+      main.app { padding: 24px 18px; gap: 20px; }
+      .app-header { flex-direction: column; align-items: stretch; gap: 10px; }
+      .app-title { text-align: center; }
+      .theme-toggle { align-self: center; }
     }
   </style>
 </head>
 <body>
   <main class="app">
+
+    <!-- Header -->
     <header class="app-header">
-      <h1 class="app-title">Gridfinium</h1>
-      <button type="button" class="theme-toggle" id="theme-toggle" aria-pressed="false" aria-label="Switch to dark mode">
+      <div>
+        <h1 class="app-title">Gridfinium</h1>
+        <p class="app-subtitle">
+          Photograph an object on a sheet of letter paper — Gridfinium detects
+          the paper and object outline automatically.
+        </p>
+      </div>
+      <button type="button" class="theme-toggle" id="theme-toggle"
+              aria-pressed="false" aria-label="Switch to dark mode">
         <span class="theme-toggle__label theme-toggle__label--light">Light</span>
         <span class="theme-toggle__thumb" aria-hidden="true"></span>
         <span class="theme-toggle__label theme-toggle__label--dark">Dark</span>
       </button>
     </header>
-    <nav class="tab-bar" aria-label="Primary">
-      <button type="button" class="tab-button is-active" data-tab-target="image-tools">Image Tools</button>
-      <button type="button" class="tab-button" data-tab-target="stl-tools">STL Designer</button>
-      <button type="button" class="tab-button" data-tab-target="tests">Tests</button>
-    </nav>
 
-    <section id="image-tools" class="tab-panel is-active" aria-label="Image Tools">
-      <section class="test-image-picker" aria-labelledby="test-image-heading">
-        <div class="test-image-picker__intro">
-          <h2 id="test-image-heading" class="test-image-picker__heading">Sample</h2>
-          <p class="test-image-picker__description">Switch between the built-in test photos to see how the workflow responds. Uploading your own image will replace these samples.</p>
-        </div>
-        <div class="test-image-picker__buttons" id="test-image-picker" role="group" aria-label="Sample photos">
-          <button class="test-image-button" data-test-image-id="test-image-mouse">Mouse on paper</button>
-          <button class="test-image-button" data-test-image-id="test-image-remote">Remote on paper</button>
-          <button class="test-image-button" data-test-image-id="test-image-coaster">Coaster top on paper</button>
-        </div>
-      </section>
-
-      <h2>1. Upload File</h2>
-      <p>Upload a photo to detect and outline documents automatically.</p>
-      <input type="file" accept=".jpg,.jpeg,.png" id="file-upload" name="file-upload">
-      <div id="preview"></div>
-
-      <section class="hint-tuning-card" id="hint-tuning-card" aria-labelledby="tuning-heading">
-        <div class="hint-tuning-card__header">
-          <h2 id="tuning-heading" class="hint-tuning-card__title">Hint Tuning Parameters</h2>
-          <button type="button" class="hint-tuning-card__toggle" id="hint-tuning-toggle" aria-controls="hint-tuning-content" aria-expanded="false">
-            Show details
-          </button>
-        </div>
-        <div id="hint-tuning-content" class="hint-tuning-card__content" data-expanded="false" role="group" aria-describedby="tuning-heading">
-          <p class="hint-tuning-card__description">Use these sliders to guide hint-based selections toward the object you care about.</p>
-          <div class="tuning-grid">
-          <div class="tuning-field">
-            <label for="hint-threshold-low">Canny low threshold</label>
-            <input type="number" id="hint-threshold-low" name="hint-threshold-low" min="0" max="255" step="1" value="10">
-            <p class="tuning-note">Lower values pick up faint edges. Raise this if tiny textures cause noisy selections.</p>
-          </div>
-          <div class="tuning-field">
-            <label for="hint-threshold-high">Canny high threshold</label>
-            <input type="number" id="hint-threshold-high" name="hint-threshold-high" min="0" max="255" step="1" value="50">
-            <p class="tuning-note">Higher numbers keep only strong borders. Drop it to help latch onto small items like the coaster.</p>
-          </div>
-          <div class="tuning-field">
-            <label for="hint-kernel-size">Morphology kernel size</label>
-            <input type="number" id="hint-kernel-size" name="hint-kernel-size" min="1" max="31" step="1" value="5">
-            <p class="tuning-note">Controls how aggressively edges are merged. Keep it small to separate nearby shapes.</p>
-          </div>
-          <div class="tuning-field">
-            <label for="hint-min-area">Minimum contour area (%)</label>
-            <input type="number" id="hint-min-area" name="hint-min-area" min="0" max="5" step="0.001" value="0.001">
-            <p class="tuning-note">Ignores shapes below this percentage of the full image. Reduce it to keep petite selections.</p>
-          </div>
-          <div class="tuning-field">
-            <label for="hint-fusion-mode">Edge/threshold fusion</label>
-            <select id="hint-fusion-mode" name="hint-fusion-mode">
-              <option value="edge">Edge only</option>
-              <option value="threshold">Threshold only</option>
-              <option value="and" selected>Edge AND Threshold</option>
-              <option value="or">Edge OR Threshold</option>
-            </select>
-            <p class="tuning-note">Choose how edge and threshold maps combine when building hint contours.</p>
-          </div>
-          <div class="tuning-field">
-            <label for="hint-paper-tolerance">Paper similarity tolerance (%)</label>
-            <input type="number" id="hint-paper-tolerance" name="hint-paper-tolerance" min="0" max="100" step="0.01" value="10">
-            <p class="tuning-note">Reject hint contours whose size is within this percent of the paper outline. Raise it if the paper keeps winning.</p>
-          </div>
-        </div>
-        <label class="tuning-checkbox" for="hint-show-steps">
-          <input type="checkbox" id="hint-show-steps" name="hint-show-steps" checked>
-          <span>Display paper processing steps while outlining</span>
-        </label>
-        <label class="tuning-checkbox" for="hint-enable-erode">
-          <input type="checkbox" id="hint-enable-erode" name="hint-enable-erode" checked>
-          <span>Apply <code>cv.erode()</code> refinement after dilation</span>
-        </label>
-        </div>
-      </section>
-    </section>
-
-    <section id="stl-tools" class="tab-panel" aria-label="STL Designer">
-      <h2>Create &amp; Preview STL Files</h2>
-      <p>Adjust the dimensions of your model in inches, preview it in 3D, and export a ready-to-print STL file.</p>
-      <div class="stl-grid">
-        <form class="stl-form" aria-describedby="stl-summary">
-          <label>
-            Width (X)
-            <input type="number" id="stl-width" name="stl-width" min="0.1" step="0.1" value="4">
-          </label>
-          <label>
-            Depth (Y)
-            <input type="number" id="stl-depth" name="stl-depth" min="0.1" step="0.1" value="6">
-          </label>
-          <label>
-            Height (Z)
-            <input type="number" id="stl-height" name="stl-height" min="0.1" step="0.1" value="3">
-          </label>
-          <p id="stl-summary" class="stl-summary" role="status">Cube dimensions: 4&quot; × 6&quot; × 3&quot;.</p>
-          <div class="stl-actions">
-            <button type="button" class="stl-button" id="stl-download">Download STL</button>
-            <button type="button" class="stl-button secondary" id="stl-reset">Reset to 4&quot; × 6&quot; × 3&quot;</button>
-          </div>
-        </form>
-        <div class="stl-viewer" id="stl-viewer" aria-label="3D preview" role="img"></div>
-      </div>
-      <p class="stl-tip">Tip: drag to rotate the model and use your scroll wheel or trackpad to zoom.</p>
-    </section>
-
-    <section id="tests" class="tab-panel" aria-label="Tests">
-      <div class="tests-panel">
-        <div>
-          <h2>In-app Tests</h2>
-          <p>Run smoke and schema checks against the current UI, detection pipeline, and STL export.</p>
-        </div>
-        <div class="tests-controls">
-          <button type="button" class="tests-run-button" id="tests-run-all">Run All</button>
-        </div>
-        <div class="tests-table-wrapper">
-          <table class="tests-table">
-            <thead>
-              <tr>
-                <th>Sample</th>
-                <th>Load</th>
-                <th>Paper Detect</th>
-                <th>Overlay Init</th>
-                <th>STL Export Smoke</th>
-                <th>Overall</th>
-              </tr>
-            </thead>
-            <tbody id="tests-results-body"></tbody>
-          </table>
-        </div>
-        <div class="tests-cards" id="tests-results-cards" aria-live="polite"></div>
-        <div id="tests-sandbox" class="tests-sandbox" aria-hidden="true"></div>
+    <!-- Sample image picker -->
+    <section class="sample-picker" aria-labelledby="sample-heading">
+      <p class="sample-picker__heading" id="sample-heading">Sample images</p>
+      <p class="sample-picker__description">
+        Choose a built-in photo or upload your own object placed flat on a
+        letter-size sheet.
+      </p>
+      <div class="sample-buttons" role="group" aria-label="Sample photos">
+        <button class="sample-btn" type="button"
+                data-image-src="frontend/test-images/mouse.png.jpeg"
+                data-image-id="mouse">
+          Mouse
+        </button>
+        <button class="sample-btn" type="button"
+                data-image-src="frontend/test-images/remote.png.jpeg"
+                data-image-id="remote">
+          Remote
+        </button>
+        <button class="sample-btn" type="button"
+                data-image-src="frontend/test-images/coaster-top.png.jpeg"
+                data-image-id="coaster">
+          Coaster
+        </button>
       </div>
     </section>
+
+    <!-- Upload -->
+    <div>
+      <label class="upload-label" for="file-upload">
+        <!-- Upload icon -->
+        <svg width="17" height="17" viewBox="0 0 24 24" fill="none"
+             stroke="currentColor" stroke-width="2"
+             stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+          <polyline points="17 8 12 3 7 8"/>
+          <line x1="12" y1="3" x2="12" y2="15"/>
+        </svg>
+        Upload your own image
+        <input type="file" id="file-upload" accept=".jpg,.jpeg,.png">
+      </label>
+    </div>
+
+    <!-- Status -->
+    <div id="status" class="status" role="status" aria-live="polite">
+      Loading OpenCV…
+    </div>
+
+    <!-- Canvas with overlays -->
+    <div class="canvas-wrapper">
+      <canvas id="output-canvas"
+              aria-label="Photo with paper outline (blue) and object contour (red)">
+      </canvas>
+    </div>
+
+    <!-- Legend (shown alongside canvas) -->
+    <div class="legend" aria-hidden="true">
+      <span class="legend-item">
+        <span class="legend-swatch" style="background:#3b82f6;"></span>
+        Paper outline
+      </span>
+      <span class="legend-item">
+        <span class="legend-swatch" style="background:#ef4444;"></span>
+        Object contour
+      </span>
+    </div>
+
+    <!-- Detection results -->
+    <div id="results" aria-live="polite"></div>
+
   </main>
 </body>
 </html>


### PR DESCRIPTION
- Replace multi-tab app (STL, Tests, Hint Tuning) with a focused single-page
  detection view
- Add ObjectDetection.js: masked Canny edge detection inside the paper region
  to automatically find the main object, returns a simplified loose polygon
- Rewrite MainScript.js: auto-loads the first sample image on boot, wires
  sample picker and file upload, draws paper (blue) + object (red) overlays
  on a single canvas, computes real-world object dimensions using letter paper
  as the scale reference
- Simplify index.html: clean single-panel layout with sample picker, upload,
  status bar, capped-height canvas, overlay legend, and dimension result cards
- Paper and object pipeline fully connected end-to-end for the first time

https://claude.ai/code/session_01BhVVYCg1C28BTrzo72Za5T